### PR TITLE
OJ-1422: add release flag for contains unique

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib           	: "1.5.0"
+		cri_common_lib           	: "1.5.2"
 	]
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -125,6 +125,14 @@ Mappings:
       integration: "true"
       production: "true"
 
+  VcContainsUniqueIdMapping:
+    Environment:
+      dev: "false"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
+
   JwtTtlUnitMapping:
     Environment:
       dev: MONTHS
@@ -461,6 +469,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             Effect: Allow
             Action:
@@ -578,6 +587,14 @@ Resources:
       Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
       Type: String
       Description: Expiry date release toggle
+
+  ReleaseFlagsVcContainsUniqueIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
+      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Type: String
+      Description: Verifiable Credential Contains UniqueId Mapping
 
   ParameterDocumentCheckResultTableName:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
## Proposed changes

Use release-flag for `vc-contains-unique-id` for `di-ipv-cri-dl-api` implemented by https://github.com/alphagov/di-ipv-cri-lib/pull/244

### What changed

Added release_flag for vc-contains-unique-id this can be activated by setting the environment flag to true in the template file

```
  VcContainsUniqueIdMapping:
    Environment:
      dev: "false"
      build: "false"
      staging: "false"
      integration: "false"
      production: "false"
``` 

### Why did it change

see: https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-optionIn order to be able to distinguish one Verifiable Credential (VC) from another VC it will be necessary for VCs to be able to be uniquely identifiable

### Issue tracking

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

### Other considerations:
This PR is dependent on version 1.5.1 of the below
- see https://github.com/alphagov/di-ipv-cri-lib/pull/244

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ