### PR TITLE
LIME-837: Updating cert names for prod rotation

### DIFF
--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java
@@ -53,11 +53,11 @@ public class ParameterStoreParameters {
 
     // JWE (Public Key) - not a typo
     public static final String DCS_ENCRYPTION_CERT =
-            "DCS/JWE/encryptionCertForDrivingPermitToEncrypt-2023-10-11";
+            "DCS/JWE/encryptionCertForDrivingPermitToEncrypt-2023-10-12";
 
     // JWE (Reply Signature)
     public static final String DCS_DRIVING_PERMIT_CRI_SIGNING_CERT =
-            "DCS/JWE/signingCertForDrivingPermitToVerify-2023-10-11";
+            "DCS/JWE/signingCertForDrivingPermitToVerify-2023-10-12";
 
     // JWE (Private Key Reply Decrypt)
     public static final String DCS_DRIVING_PERMIT_ENCRYPTION_KEY =


### PR DESCRIPTION
## Proposed changes

### What changed

Renaming received DCS certificates to allow change over in prod

### Why did it change

To check differences and force redeploy of certificates

