### PR TITLE
LIME-767 Redirect users over max attempts.

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/SleepHelper.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/SleepHelper.java
@@ -39,29 +39,6 @@ public class SleepHelper {
         return timeWaited;
     }
 
-    /**
-     * Calculates a wait time based on number of calls - starting from zero for the first call.
-     * Using Thread.sleep()
-     *
-     * @param callNumber
-     * @return
-     */
-    public long sleepWithExponentialBackOff(int callNumber) throws InterruptedException {
-
-        long startTime = System.currentTimeMillis();
-
-        LOGGER.info("sleepWithExponentialBackOff start time : {}", startTime);
-
-        Thread.sleep(Math.min(calculateExponentialBackOffTimeMS(callNumber), maxSleepTimeMs));
-
-        long endTime = System.currentTimeMillis();
-        long timeWaited = (endTime - startTime);
-
-        LOGGER.info("sleepWithExponentialBackOff end time : {}", endTime);
-
-        return timeWaited;
-    }
-
     private long calculateExponentialBackOffTimeMS(int callNumber) {
 
         if (callNumber == 0) {

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/SleepHelperTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/SleepHelperTest.java
@@ -35,15 +35,6 @@ class SleepHelperTest {
         assertEquals(expectedWait, waitTime, EPSILON);
     }
 
-    @Test
-    void shouldSleep0msWhenCalledOnce() throws InterruptedException {
-        long expectedWait = 0;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(0);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
     void shouldBusyWait2P100ForCallN(int callNumber) {
@@ -58,34 +49,11 @@ class SleepHelperTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7})
-    void shouldSleep2P100ForCallN(int callNumber) throws InterruptedException {
-        long baseWaitTime = 100;
-        long power = callNumber - 1;
-
-        long expectedWait = (long) Math.pow(2, power) * baseWaitTime;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(callNumber);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
-    @ParameterizedTest
     @ValueSource(ints = {8, 9})
     void shouldBusyWaitMaxTimeWhenCalledMoreThan7Times(int callNumber) {
         long expectedWait = MAX_TEST_SLEEP;
 
         long waitTime = sleepHelper.busyWaitWithExponentialBackOff(callNumber);
-
-        assertEquals(expectedWait, waitTime, EPSILON);
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {8, 9})
-    void shouldSleepMaxTimeWhenCalledMoreThan7Times(int callNumber) throws InterruptedException {
-        long expectedWait = MAX_TEST_SLEEP;
-
-        long waitTime = sleepHelper.sleepWithExponentialBackOff(callNumber);
 
         assertEquals(expectedWait, waitTime, EPSILON);
     }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
@@ -190,7 +190,7 @@ public class IssueCredentialHandler
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.INTERNAL_SERVER_ERROR, sqsException.getMessage());
         } catch (Exception e) {
-            LOGGER.error("Exception while handling lambda {}", context.getFunctionName());
+            LOGGER.error("Exception while handling lambda {}", e.getClass());
             eventProbe.counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR);
 
             LOGGER.debug(e.getMessage(), e);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
@@ -9,6 +9,10 @@ public class Definitions {
     public static final String LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_ERROR =
             "lambda_driving_permit_check_completed_error";
 
+    // Users who have reached max attempts and have gone back to the form, but will be redirected
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_USER_REDIRECTED_ATTEMPTS_OVER_MAX =
+            "lambda_driving_permit_check_user_redirected_attempts_over_max";
+
     public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK =
             "lambda_issue_credential_completed_ok";
     public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR =


### PR DESCRIPTION
## Proposed changes

### What changed

Recovery redirect added when users have submitted the form but are over max attempts.
Added metric for when the max attempt redirect happens.

Remove Thread.sleep() version of sleep helper.

Log the Exception class in IssueCredentialHandler generic catch

### Why did it change

A review of DL api errors shows the max attempt error as the most common, it was treated correctly as as an error. For same scenario in passport-v1 it was discovered that it possible to safely recover the user and mitigate entirely this scenario, this is now done for dl.

The Thread.sleep(), version of the backoff will never be used again and is safe to remove.
It will also remove a sonar warning.

Logging the generic exception in IssueCredentialHandler is suppressed to avoid any PII output, but the class type should be logged to aid error tracking and monitor for exceptions that could be logged safely in a separate catch.

### Issue tracking

- [LIME-767](https://govukverify.atlassian.net/browse/LIME-767)

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-767]: https://govukverify.atlassian.net/browse/LIME-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ