### PR TITLE
LIME-865 Correct VC evidence type key

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/VerifiableCredentialConstants.java
@@ -21,5 +21,7 @@ public class VerifiableCredentialConstants {
 
     public static final String VC_EVIDENCE_KEY = "evidence";
 
+    public static final String VC_EVIDENCE_TYPE_KEY = "type";
+
     private VerifiableCredentialConstants() {}
 }

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/verifiablecredential/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/verifiablecredential/Evidence.java
@@ -22,7 +22,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Evidence {
     @JsonProperty("type")
-    private EvidenceType type;
+    private String type;
 
     @JsonProperty("txn")
     private String txn;
@@ -45,11 +45,11 @@ public class Evidence {
     @JsonProperty("ci")
     private List<String> ci;
 
-    public EvidenceType getType() {
+    public String getType() {
         return type;
     }
 
-    public void setType(EvidenceType type) {
+    public void setType(String type) {
         this.type = type;
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
@@ -16,7 +16,7 @@ public class EvidenceHelper {
     public static Evidence documentCheckResultItemToEvidence(
             DocumentCheckResultItem documentCheckResultItem) {
         Evidence evidence = new Evidence();
-        evidence.setType(EvidenceType.IDENTITY_CHECK);
+        evidence.setType(EvidenceType.IDENTITY_CHECK.toString());
         evidence.setTxn(documentCheckResultItem.getTransactionId());
 
         evidence.setActivityHistoryScore(documentCheckResultItem.getActivityHistoryScore());

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.*;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
+import uk.gov.di.ipv.cri.drivingpermit.api.domain.verifiablecredential.EvidenceType;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.fixtures.TestFixtures;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.helpers.PersonIdentityDetailedHelperMapper;
@@ -123,6 +124,15 @@ class VerifiableCredentialServiceTest implements TestFixtures {
 
         JsonNode claimsSet = objectMapper.readTree(generatedClaims.toString());
         assertEquals(5, claimsSet.size());
+
+        assertEquals(
+                EvidenceType.IDENTITY_CHECK.toString(),
+                claimsSet
+                        .get(VC_CLAIM)
+                        .get(VC_EVIDENCE_KEY)
+                        .get(0)
+                        .get(VC_EVIDENCE_TYPE_KEY)
+                        .asText());
 
         assertEquals(
                 documentCheckResultItem.getContraIndicators().get(0),


### PR DESCRIPTION
## Proposed changes

### What changed

Correct VC evidence type key

### Why did it change

Value was mapped as the enum value rather than the intended string name.

### Issue tracking

- [LIME-865](https://govukverify.atlassian.net/browse/LIME-865)


[LIME-865]: https://govukverify.atlassian.net/browse/LIME-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ