### PR TITLE
LIME-750 - Dva direct Go live updates

### DIFF
--- a/acceptance-tests/src/test/resources/Data/DVAValidJsonPayload.json
+++ b/acceptance-tests/src/test/resources/Data/DVAValidJsonPayload.json
@@ -1,6 +1,6 @@
 {
   "drivingLicenceNumber": "55667788",
-  "postcode": "NW35RG",
+  "postcode": "NW3 5RG",
   "licenceIssuer": "DVA",
   "surname": "BATSON",
   "forenames": "BILLY",

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
@@ -13,17 +13,17 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
-  @drivingLicenceCRI_API @pre-merge @dev
-  Scenario: Acquire initial JWT and DVA Driving Licence Happy path
-    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
-    And Driving Licence user sends a POST request to session endpoint
-    And Driving Licence user gets a session-id
-    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
-    And Driving Licence user gets authorisation code
-    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-    Then User requests Driving Licence CRI VC
-    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+ # @drivingLicenceCRI_API @pre-merge @dev
+ # Scenario: Acquire initial JWT and DVA Driving Licence Happy path
+ #   Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+ #   And Driving Licence user sends a POST request to session endpoint
+ #   And Driving Licence user gets a session-id
+ #   When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
+ #   And Driving Licence user gets authorisation code
+ #   And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+ #   Then User requests Driving Licence CRI VC
+ #   And Driving Licence VC should contain validityScore 2 and strengthScore 3
+ #   And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
 
   @drivingLicenceCRI_API @pre-merge @dev
@@ -41,20 +41,20 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
-  @drivingLicenceCRI_API @pre-merge @dev
-  Scenario: DVA Driving Licence Retry Journey Happy Path
-    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
-    And Driving Licence user sends a POST request to session endpoint
-    And Driving Licence user gets a session-id
-    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAInvalidJsonPayload and document checking route is dcs
-    Then Driving Licence check response should contain Retry value as true
-    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
-    And Driving Licence check response should contain Retry value as false
-    And Driving Licence user gets authorisation code
-    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-    Then User requests Driving Licence CRI VC
-    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+#  @drivingLicenceCRI_API @pre-merge @dev
+#  Scenario: DVA Driving Licence Retry Journey Happy Path
+#    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+#    And Driving Licence user sends a POST request to session endpoint
+#    And Driving Licence user gets a session-id
+#    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAInvalidJsonPayload and document checking route is dcs
+#    Then Driving Licence check response should contain Retry value as true
+#    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
+#    And Driving Licence check response should contain Retry value as false
+#    And Driving Licence user gets authorisation code
+#    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+#    Then User requests Driving Licence CRI VC
+#    And Driving Licence VC should contain validityScore 2 and strengthScore 3
+#    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario Outline: Test Driving Licence API falls back to DCS when an exception occurs in the request and if exception occurs again it is thrown correctly

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
@@ -13,17 +13,17 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
- # @drivingLicenceCRI_API @pre-merge @dev
- # Scenario: Acquire initial JWT and DVA Driving Licence Happy path
- #   Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
- #   And Driving Licence user sends a POST request to session endpoint
- #   And Driving Licence user gets a session-id
- #   When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
- #   And Driving Licence user gets authorisation code
- #   And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
- #   Then User requests Driving Licence CRI VC
- #   And Driving Licence VC should contain validityScore 2 and strengthScore 3
- #   And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario: Acquire initial JWT and DVA Driving Licence Happy path
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC
+    And Driving Licence VC should contain validityScore 2 and strengthScore 3
+    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
 
   @drivingLicenceCRI_API @pre-merge @dev
@@ -41,20 +41,20 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
-#  @drivingLicenceCRI_API @pre-merge @dev
-#  Scenario: DVA Driving Licence Retry Journey Happy Path
-#    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
-#    And Driving Licence user sends a POST request to session endpoint
-#    And Driving Licence user gets a session-id
-#    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAInvalidJsonPayload and document checking route is dcs
-#    Then Driving Licence check response should contain Retry value as true
-#    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
-#    And Driving Licence check response should contain Retry value as false
-#    And Driving Licence user gets authorisation code
-#    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-#    Then User requests Driving Licence CRI VC
-#    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-#    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario: DVA Driving Licence Retry Journey Happy Path
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAInvalidJsonPayload and document checking route is dcs
+    Then Driving Licence check response should contain Retry value as true
+    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidJsonPayload and document checking route is dcs
+    And Driving Licence check response should contain Retry value as false
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC
+    And Driving Licence VC should contain validityScore 2 and strengthScore 3
+    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario Outline: Test Driving Licence API falls back to DCS when an exception occurs in the request and if exception occurs again it is thrown correctly

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -176,11 +176,11 @@ Mappings:
 
   dvaDirectEnabledMapping:
     Environment:
-      dev: "false"
-      build: "false"
-      staging: "false"
-      integration: "false"
-      production: "false"
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "true"
+      production: "true"
 
   dvlaDirectEnabledMapping:
     Environment:

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -167,7 +167,6 @@ public class DrivingPermitHandler
                     selectThirdPartyAPIService(
                             configurationService.getDvaDirectEnabled(),
                             configurationService.getDvlaDirectEnabled(),
-                            documentCheckingRoute,
                             drivingPermitFormData.getLicenceIssuer());
 
             LOGGER.info(
@@ -369,8 +368,7 @@ public class DrivingPermitHandler
     private DocumentCheckVerificationResult executeFallbackRequest(
             DrivingPermitForm drivingPermitFormData) throws Exception {
         ThirdPartyAPIService fallbackThirdPartyService =
-                selectThirdPartyAPIService(
-                        false, false, "DCS", drivingPermitFormData.getLicenceIssuer());
+                selectThirdPartyAPIService(false, false, drivingPermitFormData.getLicenceIssuer());
         eventProbe.counterMetric(DL_FALL_BACK_EXECUTING);
         return identityVerificationService.verifyIdentity(
                 drivingPermitFormData, fallbackThirdPartyService);
@@ -396,16 +394,11 @@ public class DrivingPermitHandler
     }
 
     private ThirdPartyAPIService selectThirdPartyAPIService(
-            boolean dvaDirectEnabled,
-            boolean dvlaDirectEnabled,
-            String documentCheckingRoute,
-            String licenseIssuer) {
+            boolean dvaDirectEnabled, boolean dvlaDirectEnabled, String licenseIssuer) {
 
         IssuingAuthority issuingAuthority = IssuingAuthority.valueOf(licenseIssuer);
 
-        boolean direct = "direct".equals(documentCheckingRoute);
-
-        if (direct && (issuingAuthority == IssuingAuthority.DVA) && dvaDirectEnabled) {
+        if ((issuingAuthority == IssuingAuthority.DVA) && dvaDirectEnabled) {
             return thirdPartyAPIServiceFactory.getDvaThirdPartyAPIService();
         } else if ((issuingAuthority == IssuingAuthority.DVLA) && dvlaDirectEnabled) {
             return thirdPartyAPIServiceFactory.getDvlaThirdPartyAPIService();

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -481,37 +481,24 @@ class DrivingPermitHandlerTest {
 
     @ParameterizedTest
     @CsvSource({
-        // dvaEnabled, dvlaEnabled, documentCheckingRoute, licenseIssuer, expected api
+        // dvaEnabled, dvlaEnabled, licenseIssuer, expected api
 
-        // API's enabled/ disabled, header has DCS
-        "false, false, dcs, DVA, DcsThirdPartyDocumentGateway",
-        "false, false, dcs, DVLA, DcsThirdPartyDocumentGateway",
-        "true, true, dcs, DVA, DcsThirdPartyDocumentGateway",
-        "true, true, dcs, DVLA, DvlaThirdPartyDocumentGateway",
-
-        // API's enabled/ disabled, header has direct
-        "false, false, direct, DVA, DcsThirdPartyDocumentGateway",
-        "false, false, direct, DVLA, DcsThirdPartyDocumentGateway",
-        "true, true, direct, DVA, DvaThirdPartyDocumentGateway",
-        "true, true, direct, DVLA, DvlaThirdPartyDocumentGateway",
-
-        // Only one direct api is enabled, header has direct (ensure api feature flags are
+        // Only one direct api is enabled (ensure api feature flags are
         // independent)
-        "false, true, direct, DVA, DcsThirdPartyDocumentGateway",
-        "true, false, direct, DVLA, DcsThirdPartyDocumentGateway",
-        "true, false, direct, DVA, DvaThirdPartyDocumentGateway",
-        "false, true, direct, DVLA, DvlaThirdPartyDocumentGateway",
+        "false, true, DVA, DcsThirdPartyDocumentGateway",
+        "true, false, DVLA, DcsThirdPartyDocumentGateway",
+        "true, false, DVA, DvaThirdPartyDocumentGateway",
+        "false, true, DVLA, DvlaThirdPartyDocumentGateway",
 
         // Failsafe for no header present
-        "false, false, not-present, DVA, DcsThirdPartyDocumentGateway",
-        "false, false, not-present, DVLA, DcsThirdPartyDocumentGateway",
-        "true, true, not-present, DVA, DcsThirdPartyDocumentGateway",
-        "true, true, not-present, DVLA, DvlaThirdPartyDocumentGateway",
+        "false, false, DVA, DcsThirdPartyDocumentGateway",
+        "false, false, DVLA, DcsThirdPartyDocumentGateway",
+        "true, true, DVA, DvaThirdPartyDocumentGateway",
+        "true, true, DVLA, DvlaThirdPartyDocumentGateway",
     })
     void shouldSelectCorrectThirdPartyAPIServiceForEachIssuerAndFeatureToggle(
             boolean dvaEnabled,
             boolean dvlaEnabled,
-            String documentCheckingRoute,
             String licenseIssuer,
             String expectedServiceName)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
@@ -519,7 +506,7 @@ class DrivingPermitHandlerTest {
         IssuingAuthority issuingAuthority = IssuingAuthority.valueOf(licenseIssuer);
 
         // This section mocks the gets (if called) from the ThirdPartyAPIServiceFactory
-        if (dvaEnabled && "direct".equals(documentCheckingRoute) && (DVA == issuingAuthority)) {
+        if (dvaEnabled && (DVA == issuingAuthority)) {
             when(mockThirdPartyAPIServiceFactory.getDvaThirdPartyAPIService())
                     .thenReturn(mockDvaThirdPartyDocumentGateway);
         } else if (dvlaEnabled && (DVLA == issuingAuthority)) {
@@ -545,22 +532,14 @@ class DrivingPermitHandlerTest {
 
         Method privateDetermineThirdPartyAPIServiceMethod =
                 DrivingPermitHandler.class.getDeclaredMethod(
-                        "selectThirdPartyAPIService",
-                        boolean.class,
-                        boolean.class,
-                        String.class,
-                        String.class);
+                        "selectThirdPartyAPIService", boolean.class, boolean.class, String.class);
         privateDetermineThirdPartyAPIServiceMethod.setAccessible(true);
 
         // Call the private method and capture result
         ThirdPartyAPIService thirdPartyAPIService =
                 (ThirdPartyAPIService)
                         privateDetermineThirdPartyAPIServiceMethod.invoke(
-                                spyHandler,
-                                dvaEnabled,
-                                dvlaEnabled,
-                                documentCheckingRoute,
-                                licenseIssuer);
+                                spyHandler, dvaEnabled, dvlaEnabled, licenseIssuer);
 
         assertEquals(expectedServiceName, thirdPartyAPIService.getClass().getSimpleName());
     }


### PR DESCRIPTION
### What changed

Removed document Checking route header logic for thirdPartyApiSelection as no longer needed post go live, aligned tests with this updated logic, updated dvaDirectEnabled mappings in template. 

All of this will result in users being routed to the new dvaDirectRoute once in prod
