### PR TITLE
LIME-867: Removing the fallback logic for DL CRI

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
@@ -80,36 +80,6 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
 
-  @drivingLicenceCRI_API @pre-merge @dev @dvlaDirect
-  Scenario Outline: Test Driving Licence API falls back to DCS when user is marked as unverified during the DVAD fallback window and the DCS request succeeds
-    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
-    And Driving Licence user sends a POST request to session endpoint
-    And Driving Licence user gets a session-id
-    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest <PassportJsonPayload> and document checking route is direct
-    And Driving Licence user gets authorisation code
-    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-    Then User requests Driving Licence CRI VC
-    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in <checkDetails> checkDetails
-    Examples:
-      |PassportJsonPayload                         | checkDetails |
-      |DVLA-DCS-InvalidJsonPayload                 | success      |
-
-  @drivingLicenceCRI_API @pre-merge @dev @dvlaDirect
-  Scenario Outline: Test passport API falls back to DCS when the request throws an exception during the DVAD fallback window and the DCS request succeeds
-    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
-    And Driving Licence user sends a POST request to session endpoint
-    And Driving Licence user gets a session-id
-    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest <PassportJsonPayload> and document checking route is direct
-    And Driving Licence user gets authorisation code
-    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-    Then User requests Driving Licence CRI VC
-    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in <checkDetails> checkDetails
-    Examples:
-      |PassportJsonPayload                             | checkDetails |
-      |DVLAServerErrorInvalidJsonPayload               | success      |
-
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario: DVLA Driving Licence user fails first attempt with dvla direct as document checking route but VC is still created
     Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -33,8 +33,6 @@ import uk.gov.di.ipv.cri.drivingpermit.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.configuration.ConfigurationService;
-import uk.gov.di.ipv.cri.drivingpermit.api.service.dcs.DcsThirdPartyDocumentGateway;
-import uk.gov.di.ipv.cri.drivingpermit.api.service.dva.DvaThirdPartyDocumentGateway;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.CheckDetails;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority;
@@ -52,8 +50,6 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority.DVLA;
-import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DL_FALL_BACK_EXECUTING;
-import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DL_VERIFICATION_FALLBACK_DEVIATION;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_RETRY;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_UNVERIFIED;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_VERIFIED_PREFIX;
@@ -162,7 +158,6 @@ public class DrivingPermitHandler
             DrivingPermitForm drivingPermitFormData =
                     parseDrivingPermitFormRequest(input.getBody());
 
-            String documentCheckingRoute = headers.get(HEADER_DOCUMENT_CHECKING_ROUTE);
             ThirdPartyAPIService thirdPartyAPIService =
                     selectThirdPartyAPIService(
                             configurationService.getDvaDirectEnabled(),
@@ -172,39 +167,9 @@ public class DrivingPermitHandler
             LOGGER.info(
                     "Verifying document details using {}", thirdPartyAPIService.getServiceName());
 
-            DocumentCheckVerificationResult documentCheckVerificationResult = null;
-
-            boolean thirdPartyIsDcs =
-                    thirdPartyAPIService
-                            .getServiceName()
-                            .equals(DcsThirdPartyDocumentGateway.class.getSimpleName());
-
-            boolean thirdPartyIsDva =
-                    thirdPartyAPIService
-                            .getServiceName()
-                            .equals(DvaThirdPartyDocumentGateway.class.getSimpleName());
-
-            try {
-                documentCheckVerificationResult =
-                        identityVerificationService.verifyIdentity(
-                                drivingPermitFormData, thirdPartyAPIService);
-                if (!thirdPartyIsDcs && !thirdPartyIsDva) {
-                    LOGGER.info("Checking if verification fallback is required");
-                    documentCheckVerificationResult =
-                            executeFallbackIfDocumentFailedToVerify(
-                                    documentCheckVerificationResult, drivingPermitFormData);
-                }
-            } catch (Exception e) {
-                LOGGER.info("Exception {}, checking if fallback is required", e.getClass());
-
-                if (!thirdPartyIsDcs && !thirdPartyIsDva) {
-                    LOGGER.info(
-                            "Exception has occurred during fallback window. Executing request with DVAD");
-                    documentCheckVerificationResult = executeFallbackRequest(drivingPermitFormData);
-                } else {
-                    throw e;
-                }
-            }
+            DocumentCheckVerificationResult documentCheckVerificationResult =
+                    identityVerificationService.verifyIdentity(
+                            drivingPermitFormData, thirdPartyAPIService);
 
             documentCheckVerificationResult.setAttemptCount(sessionItem.getAttemptCount());
 
@@ -363,34 +328,6 @@ public class DrivingPermitHandler
 
         return new IdentityVerificationService(
                 new FormDataValidator(), serviceFactory.getEventProbe());
-    }
-
-    private DocumentCheckVerificationResult executeFallbackRequest(
-            DrivingPermitForm drivingPermitFormData) throws Exception {
-        ThirdPartyAPIService fallbackThirdPartyService =
-                selectThirdPartyAPIService(false, false, drivingPermitFormData.getLicenceIssuer());
-        eventProbe.counterMetric(DL_FALL_BACK_EXECUTING);
-        return identityVerificationService.verifyIdentity(
-                drivingPermitFormData, fallbackThirdPartyService);
-    }
-
-    private DocumentCheckVerificationResult executeFallbackIfDocumentFailedToVerify(
-            DocumentCheckVerificationResult documentDataVerificationResult,
-            DrivingPermitForm drivingPermitFormData)
-            throws Exception {
-        if (!documentDataVerificationResult.isVerified()
-                || (documentDataVerificationResult.getContraIndicators() != null
-                        && !documentDataVerificationResult.getContraIndicators().isEmpty())) {
-            LOGGER.info(
-                    "Document has been marked unverified during fallback window. Executing request with Direct connection");
-            documentDataVerificationResult = executeFallbackRequest(drivingPermitFormData);
-            if (documentDataVerificationResult.isVerified()) {
-                eventProbe.counterMetric(DL_VERIFICATION_FALLBACK_DEVIATION);
-                LOGGER.warn(
-                        "Document has been verified using DCS that failed verification using Direct connection");
-            }
-        }
-        return documentDataVerificationResult;
     }
 
     private ThirdPartyAPIService selectThirdPartyAPIService(

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -47,16 +47,12 @@ import uk.gov.di.ipv.cri.drivingpermit.library.persistence.item.DocumentCheckRes
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.time.Clock;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
@@ -67,8 +63,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority.DVA;
 import static uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority.DVLA;
-import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DL_FALL_BACK_EXECUTING;
-import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DL_VERIFICATION_FALLBACK_DEVIATION;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_RETRY;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_UNVERIFIED;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_VERIFIED_PREFIX;
@@ -165,8 +159,6 @@ class DrivingPermitHandlerTest {
         when(mockConfigurationService.getDvlaDirectEnabled()).thenReturn(true);
         when(mockDvlaThirdPartyDocumentGateway.getServiceName())
                 .thenReturn(DvlaThirdPartyDocumentGateway.class.getSimpleName());
-        when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
-                .thenReturn(mockDcsThirdPartyDocumentGateway);
         when(mockThirdPartyAPIServiceFactory.getDvlaThirdPartyAPIService())
                 .thenReturn(mockDvlaThirdPartyDocumentGateway);
 
@@ -190,8 +182,6 @@ class DrivingPermitHandlerTest {
 
         verify(mockIdentityVerificationService)
                 .verifyIdentity(drivingPermitForm, mockDvlaThirdPartyDocumentGateway);
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(drivingPermitForm, mockDcsThirdPartyDocumentGateway);
         verify(mockDataStore).create(documentCheckResultItem);
         assertNotNull(responseEvent);
         assertEquals(200, responseEvent.getStatusCode());
@@ -542,270 +532,5 @@ class DrivingPermitHandlerTest {
                                 spyHandler, dvaEnabled, dvlaEnabled, licenseIssuer);
 
         assertEquals(expectedServiceName, thirdPartyAPIService.getClass().getSimpleName());
-    }
-
-    @Test
-    void handleResponseShouldReturnOkResponseWhenDVLAFailsAndWeHaveFallenBackToDCS()
-            throws JsonProcessingException, OAuthErrorResponseException {
-        final String SESSION_ID = UUID.randomUUID().toString();
-        final String STATE = UUID.randomUUID().toString();
-        final String REDIRECT_URI = "https://example.com";
-        final int ATTEMPT_NO = 0; // No previous attempt
-
-        DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        String testRequestBody = realObjectMapper.writeValueAsString(drivingPermitForm);
-
-        DocumentCheckVerificationResult testDocumentDataVerificationResult =
-                DocumentCheckVerificationResultDataGenerator.generate(drivingPermitForm);
-
-        APIGatewayProxyRequestEvent mockRequestEvent =
-                Mockito.mock(APIGatewayProxyRequestEvent.class);
-
-        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders =
-                Map.of("session_id", SESSION_ID, "document-checking-route", "direct");
-        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
-
-        final var sessionItem = new SessionItem();
-        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
-        sessionItem.setState(STATE);
-        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
-        sessionItem.setAttemptCount(ATTEMPT_NO);
-        when(mockObjectMapper.readValue(testRequestBody, DrivingPermitForm.class))
-                .thenReturn(drivingPermitForm);
-        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
-        when(mockConfigurationService.getMaxAttempts()).thenReturn(2);
-
-        when(mockConfigurationService.getDvlaDirectEnabled()).thenReturn(true);
-
-        when(mockDvlaThirdPartyDocumentGateway.getServiceName())
-                .thenReturn(DvlaThirdPartyDocumentGateway.class.getSimpleName());
-        when(mockThirdPartyAPIServiceFactory.getDvlaThirdPartyAPIService())
-                .thenReturn(mockDvlaThirdPartyDocumentGateway);
-        when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
-                .thenReturn(mockDcsThirdPartyDocumentGateway);
-        when(mockIdentityVerificationService.verifyIdentity(
-                        eq(drivingPermitForm), any(ThirdPartyAPIService.class)))
-                .thenThrow(new RuntimeException("DVLA is broke"))
-                .thenReturn(testDocumentDataVerificationResult);
-
-        when(context.getFunctionName()).thenReturn("functionName");
-        when(context.getFunctionVersion()).thenReturn("1.0");
-
-        this.drivingPermitHandler =
-                new DrivingPermitHandler(
-                        mockServiceFactory,
-                        mockThirdPartyAPIServiceFactory,
-                        mockIdentityVerificationService);
-
-        APIGatewayProxyResponseEvent responseEvent =
-                drivingPermitHandler.handleRequest(mockRequestEvent, context);
-
-        InOrder inOrder = inOrder(mockEventProbe);
-        inOrder.verify(mockEventProbe).counterMetric(DL_FALL_BACK_EXECUTING);
-        inOrder.verify(mockEventProbe)
-                .counterMetric(LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
-        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_OK);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DvlaThirdPartyDocumentGateway.class));
-        verify(mockDataStore).create(any());
-        verifyNoMoreInteractions(mockEventProbe);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DcsThirdPartyDocumentGateway.class));
-        JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
-
-        assertNotNull(responseEvent);
-        assertEquals(200, responseEvent.getStatusCode());
-        assertEquals("false", responseTreeRootNode.findPath("retry").toString());
-        assertNull(responseTreeRootNode.findPath("redirectUrl").textValue());
-    }
-
-    @Test
-    void handleResponseShouldCheckAgainstDCSWhenHMPOReturnsUnverified()
-            throws JsonProcessingException, OAuthErrorResponseException {
-        final String SESSION_ID = UUID.randomUUID().toString();
-        final String STATE = UUID.randomUUID().toString();
-        final String REDIRECT_URI = "https://example.com";
-        final int ATTEMPT_NO = 0; // No previous attempt
-
-        DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        String testRequestBody = realObjectMapper.writeValueAsString(drivingPermitForm);
-
-        DocumentCheckVerificationResult testDocumentDataVerificationResult =
-                DocumentCheckVerificationResultDataGenerator.generate(drivingPermitForm);
-        DocumentCheckVerificationResult testDocumentDataVerificationResultUnverified =
-                DocumentCheckVerificationResultDataGenerator.generate(drivingPermitForm);
-        testDocumentDataVerificationResultUnverified.setVerified(false);
-
-        APIGatewayProxyRequestEvent mockRequestEvent =
-                Mockito.mock(APIGatewayProxyRequestEvent.class);
-
-        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders =
-                Map.of("session_id", SESSION_ID, "document-checking-route", "direct");
-        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
-
-        final var sessionItem = new SessionItem();
-        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
-        sessionItem.setState(STATE);
-        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
-        sessionItem.setAttemptCount(ATTEMPT_NO);
-        when(mockObjectMapper.readValue(testRequestBody, DrivingPermitForm.class))
-                .thenReturn(drivingPermitForm);
-        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
-        when(mockConfigurationService.getDvlaDirectEnabled()).thenReturn(true);
-        when(mockConfigurationService.getMaxAttempts()).thenReturn(2);
-
-        when(mockDvlaThirdPartyDocumentGateway.getServiceName())
-                .thenReturn(DvlaThirdPartyDocumentGateway.class.getSimpleName());
-        when(mockThirdPartyAPIServiceFactory.getDvlaThirdPartyAPIService())
-                .thenReturn(mockDvlaThirdPartyDocumentGateway);
-        when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
-                .thenReturn(mockDcsThirdPartyDocumentGateway);
-        when(mockIdentityVerificationService.verifyIdentity(
-                        eq(drivingPermitForm), any(ThirdPartyAPIService.class)))
-                .thenReturn(
-                        testDocumentDataVerificationResultUnverified,
-                        testDocumentDataVerificationResult);
-
-        when(context.getFunctionName()).thenReturn("functionName");
-        when(context.getFunctionVersion()).thenReturn("1.0");
-
-        this.drivingPermitHandler =
-                new DrivingPermitHandler(
-                        mockServiceFactory,
-                        mockThirdPartyAPIServiceFactory,
-                        mockIdentityVerificationService);
-
-        APIGatewayProxyResponseEvent responseEvent =
-                drivingPermitHandler.handleRequest(mockRequestEvent, context);
-
-        InOrder inOrder = inOrder(mockEventProbe);
-        inOrder.verify(mockEventProbe).counterMetric(DL_FALL_BACK_EXECUTING);
-        inOrder.verify(mockEventProbe).counterMetric(DL_VERIFICATION_FALLBACK_DEVIATION);
-
-        inOrder.verify(mockEventProbe)
-                .counterMetric(LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_VERIFIED_PREFIX + 1);
-        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_OK);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DvlaThirdPartyDocumentGateway.class));
-        verify(mockDataStore).create(any());
-        verifyNoMoreInteractions(mockEventProbe);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DcsThirdPartyDocumentGateway.class));
-        JsonNode responseTreeRootNode = realObjectMapper.readTree(responseEvent.getBody());
-
-        assertNotNull(responseEvent);
-        assertEquals(200, responseEvent.getStatusCode());
-        assertEquals("false", responseTreeRootNode.findPath("retry").toString());
-        assertNull(responseTreeRootNode.findPath("redirectUrl").textValue());
-    }
-
-    @Test
-    void handleResponseShouldReturnExceptionIfBothHMPOandDCSFail()
-            throws JsonProcessingException, OAuthErrorResponseException {
-        final String SESSION_ID = UUID.randomUUID().toString();
-        final String STATE = UUID.randomUUID().toString();
-        final String REDIRECT_URI = "https://example.com";
-        final int ATTEMPT_NO = 0; // No previous attempt
-
-        DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        String testRequestBody = realObjectMapper.writeValueAsString(drivingPermitForm);
-
-        DocumentCheckVerificationResult testDocumentDataVerificationResult =
-                DocumentCheckVerificationResultDataGenerator.generate(drivingPermitForm);
-        DocumentCheckVerificationResult testDocumentDataVerificationResultUnverified =
-                DocumentCheckVerificationResultDataGenerator.generate(drivingPermitForm);
-        testDocumentDataVerificationResultUnverified.setVerified(false);
-
-        APIGatewayProxyRequestEvent mockRequestEvent =
-                Mockito.mock(APIGatewayProxyRequestEvent.class);
-
-        when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders =
-                Map.of("session_id", SESSION_ID, "document-checking-route", "direct");
-        when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
-
-        final var sessionItem = new SessionItem();
-        sessionItem.setSessionId(UUID.fromString(SESSION_ID));
-        sessionItem.setState(STATE);
-        sessionItem.setRedirectUri(URI.create(REDIRECT_URI));
-        sessionItem.setAttemptCount(ATTEMPT_NO);
-        when(mockObjectMapper.readValue(testRequestBody, DrivingPermitForm.class))
-                .thenReturn(drivingPermitForm);
-        when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
-        when(mockConfigurationService.getMaxAttempts()).thenReturn(2);
-
-        when(mockConfigurationService.getDvlaDirectEnabled()).thenReturn(true);
-
-        when(mockDvlaThirdPartyDocumentGateway.getServiceName())
-                .thenReturn(DvlaThirdPartyDocumentGateway.class.getSimpleName());
-        when(mockThirdPartyAPIServiceFactory.getDvlaThirdPartyAPIService())
-                .thenReturn(mockDvlaThirdPartyDocumentGateway);
-        when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
-                .thenReturn(mockDcsThirdPartyDocumentGateway);
-        when(mockIdentityVerificationService.verifyIdentity(
-                        eq(drivingPermitForm), any(ThirdPartyAPIService.class)))
-                .thenThrow(new RuntimeException("DVLA is broke"));
-
-        when(context.getFunctionName()).thenReturn("functionName");
-        when(context.getFunctionVersion()).thenReturn("1.0");
-
-        this.drivingPermitHandler =
-                new DrivingPermitHandler(
-                        mockServiceFactory,
-                        mockThirdPartyAPIServiceFactory,
-                        mockIdentityVerificationService);
-
-        APIGatewayProxyResponseEvent responseEvent =
-                drivingPermitHandler.handleRequest(mockRequestEvent, context);
-
-        InOrder inOrder = inOrder(mockEventProbe);
-        inOrder.verify(mockEventProbe).counterMetric(DL_FALL_BACK_EXECUTING);
-        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_ERROR);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DvlaThirdPartyDocumentGateway.class));
-        verifyNoMoreInteractions(mockEventProbe);
-
-        verify(mockIdentityVerificationService)
-                .verifyIdentity(eq(drivingPermitForm), any(DcsThirdPartyDocumentGateway.class));
-
-        assertNotNull(responseEvent);
-        assertEquals(500, responseEvent.getStatusCode());
-    }
-
-    private DocumentCheckResultItem mapDocumentDataVerificationResultToDocumentCheckResultItem(
-            SessionItem sessionItem,
-            DocumentCheckVerificationResult documentDataVerificationResult,
-            DrivingPermitForm drivingPermitForm) {
-        DocumentCheckResultItem documentCheckResultItem = new DocumentCheckResultItem();
-
-        documentCheckResultItem.setSessionId(sessionItem.getSessionId());
-
-        documentCheckResultItem.setTransactionId(documentDataVerificationResult.getTransactionId());
-        documentCheckResultItem.setContraIndicators(
-                documentDataVerificationResult.getContraIndicators());
-        documentCheckResultItem.setStrengthScore(documentDataVerificationResult.getStrengthScore());
-        documentCheckResultItem.setValidityScore(documentDataVerificationResult.getValidityScore());
-
-        String passportNo = drivingPermitForm.getDrivingLicenceNumber();
-        String passportExpiryDate = String.valueOf(drivingPermitForm.getExpiryDate());
-        documentCheckResultItem.setDocumentNumber(passportNo);
-        documentCheckResultItem.setExpiryDate(passportExpiryDate);
-
-        documentCheckResultItem.setCheckMethod(
-                documentDataVerificationResult.getCheckDetails().getCheckMethod());
-
-        final long ttl = mockConfigurationService.getDocumentCheckItemExpirationEpoch();
-
-        documentCheckResultItem.setExpiry(
-                Clock.systemUTC().instant().plus(ttl, ChronoUnit.SECONDS).getEpochSecond());
-
-        return documentCheckResultItem;
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Removed the logic from the DL CRI which allows failed checks to fall back to DCS

### Why did it change

Direct connections have been live for a week now without issue so dynamic fallbacks are no longer required

