### PR TITLE
LIME-864: Removed remaining set document checking route

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
@@ -32,7 +32,6 @@ Feature: Driving License Test
   Scenario:User Selects DVLA and landed in DVLA page
     Given I click on DVLA radio button and Continue
     Then I should on the page DVLA Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK
-    And I set the document checking route
     And The test is complete and I close the driver
 
   @DrivingLicenceTest @build @staging @integration


### PR DESCRIPTION
## Proposed changes

### What changed

Removed set document checking route

### Why did it change

So that tests can pass following merge of LIME-864

