### PR TITLE
LIME-862: Removing the 4XX alarm from the DL CRI

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1053,50 +1053,6 @@ Resources:
             Period: 300
             Stat: Sum
 
-  DLAPIGW4XXErrors:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmDescription: !Sub Driving Licence ${Environment} API Gateway 4XX errors
-      ActionsEnabled: true
-      AlarmActions:
-        - !Ref AlarmTopicDL
-      OKActions:
-        - !Ref AlarmTopicDL
-      InsufficientDataActions: [ ]
-      Dimensions: [ ]
-      DatapointsToAlarm: 3
-      EvaluationPeriods: 3
-      Threshold: 2
-      ComparisonOperator: GreaterThanThreshold
-      TreatMissingData: notBreaching
-      Metrics:
-        - Id: e1
-          Label: Expression1
-          ReturnData: true
-          Expression: SUM(METRICS())
-        - Id: m1
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 4XXError
-              Dimensions:
-                - Name: ApiName
-                  Value: !Sub "${AWS::StackName}-PublicDLApi"
-            Period: 300
-            Stat: Sum
-        - Id: m2
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 4XXError
-              Dimensions:
-                - Name: ApiName
-                  Value: !Sub "${AWS::StackName}-PrivateDLApi"
-            Period: 300
-            Stat: Sum
-
   DrivingLicenceLambdaInvocationDeviation:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
## Proposed changes

### What changed

Removed 4XX alarm from template

### Why did it change

So that we are no longer running P1 alerts for 400's in production

