### PR TITLE
LIME-906 Correct Invalid HTTPRetryer exceptions and adjust DVLA timeout values to account for 2 endpoints with 1 retry each

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
@@ -20,7 +20,9 @@ import java.security.cert.CertificateException;
 
 public class ThirdPartyAPIServiceFactory {
 
-    private static final int MAX_HTTP_RETRIES = 2;
+    private static final int MAX_HTTP_DCS_RETRIES = 2;
+    private static final int MAX_HTTP_DVA_RETRIES = 2;
+    private static final int MAX_HTTP_DVLA_RETRIES = 1;
 
     private static final int DCS = 0;
     private static final int DVA = 1;
@@ -58,7 +60,7 @@ public class ThirdPartyAPIServiceFactory {
         CloseableHttpClient httpClient =
                 serviceFactory.generateDcsHttpClient(configurationService, tlsOn);
 
-        HttpRetryer httpRetryer = new HttpRetryer(httpClient, eventProbe, MAX_HTTP_RETRIES);
+        HttpRetryer httpRetryer = new HttpRetryer(httpClient, eventProbe, MAX_HTTP_DCS_RETRIES);
 
         return new DcsThirdPartyDocumentGateway(
                 objectMapper,
@@ -85,7 +87,7 @@ public class ThirdPartyAPIServiceFactory {
         CloseableHttpClient httpClient =
                 serviceFactory.generateDvaHttpClient(configurationService, tlsOn);
 
-        HttpRetryer httpRetryer = new HttpRetryer(httpClient, eventProbe, MAX_HTTP_RETRIES);
+        HttpRetryer httpRetryer = new HttpRetryer(httpClient, eventProbe, MAX_HTTP_DVA_RETRIES);
 
         return new DvaThirdPartyDocumentGateway(
                 objectMapper,
@@ -102,7 +104,7 @@ public class ThirdPartyAPIServiceFactory {
         EventProbe eventProbe = serviceFactory.getEventProbe();
         HttpRetryer httpRetryer =
                 new HttpRetryer(
-                        serviceFactory.generateDvlaHttpClient(), eventProbe, MAX_HTTP_RETRIES);
+                        serviceFactory.generateDvlaHttpClient(), eventProbe, MAX_HTTP_DVLA_RETRIES);
         DvlaEndpointFactory dvlaEndpointFactory =
                 new DvlaEndpointFactory(serviceFactory, httpRetryer);
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
@@ -75,7 +75,7 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
         this.httpRetryer = httpRetryer;
         this.eventProbe = eventProbe;
 
-        this.defaultRequestConfig = new HttpRequestConfig().getDefaultRequestConfig();
+        this.defaultRequestConfig = new HttpRequestConfig().getDCSDefaultRequestConfig();
         this.httpRetryStatusConfig = new DcsHttpRetryStatusConfig();
     }
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaEndpointFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaEndpointFactory.java
@@ -27,7 +27,8 @@ public class DvlaEndpointFactory {
         EventProbe eventProbe = serviceFactory.getEventProbe();
 
         // Same on all endpoints
-        RequestConfig defaultRequestConfig = new HttpRequestConfig().getDefaultRequestConfig();
+        RequestConfig defaultRequestConfig =
+                new HttpRequestConfig().getDVLAEndpointsRequestConfig();
 
         tokenRequestService =
                 new TokenRequestService(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/HttpRequestConfig.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/HttpRequestConfig.java
@@ -5,29 +5,51 @@ import org.apache.http.client.config.RequestConfig;
 /** A shared RequestConfig applied to each http request to DVLA ThirdPartyAPI endpoints. */
 public class HttpRequestConfig {
 
-    // HTTP client connection stage timeouts Totals are additive.
+    // HTTP client connection stage timeouts Totals are additive - values in milliseconds.
 
+    // DCS - 1x endpoint
+    // Connection pool Req
+    private static final int DCS_HTTP_CONN_POOL_REQ_TIMEOUT_MS = 5000;
     // Initial connection attempt
-    private static final int HTTP_INITIAL_CONNECTION_TIMEOUT_MS = 5000;
-
+    private static final int DCS_HTTP_INITIAL_CONNECTION_TIMEOUT_MS = 5000;
     // Reading a packet
-    private static final int HTTP_SOCKET_READ_TIMEOUT_MS = 10000;
+    private static final int DCS_HTTP_SOCKET_READ_TIMEOUT_MS = 10000;
 
-    // Requesting a connection from the http clients connection pool
-    private static final int HTTP_CONN_POOL_REQ_TIMEOUT_MS = 5000;
+    // DVLA - Set on 2x endpoints (token only hit as needed)
+    // Connection pool Req
+    private static final int DVLA_HTTP_CONN_POOL_REQ_TIMEOUT_MS = 500;
+    // Initial connection attempt
+    private static final int DVLA_HTTP_INITIAL_CONNECTION_TIMEOUT_MS = 500;
+    // Reading a packet (Two endpoints and 1 retry each < 30s)
+    private static final int DVLA_HTTP_SOCKET_READ_TIMEOUT_MS = 7250;
 
     /**
      * Prevents waiting until the lambda timeout is reached when there are connection issues.
      *
      * @return RequestConfig
      */
-    public RequestConfig getDefaultRequestConfig() {
-        // RequestConfig is set per request to apply the timeouts
+    public RequestConfig getDCSDefaultRequestConfig() {
+        // RequestConfig needs to be set on each request to the endpoint to apply the timeouts
         // Only socket read maters if the HTTP client is able to re-use a connection
         return RequestConfig.custom()
-                .setConnectTimeout(HTTP_INITIAL_CONNECTION_TIMEOUT_MS)
-                .setSocketTimeout(HTTP_SOCKET_READ_TIMEOUT_MS)
-                .setConnectionRequestTimeout(HTTP_CONN_POOL_REQ_TIMEOUT_MS)
+                .setConnectionRequestTimeout(DCS_HTTP_CONN_POOL_REQ_TIMEOUT_MS)
+                .setConnectTimeout(DCS_HTTP_INITIAL_CONNECTION_TIMEOUT_MS)
+                .setSocketTimeout(DCS_HTTP_SOCKET_READ_TIMEOUT_MS)
+                .build();
+    }
+
+    /**
+     * Prevents waiting until the lambda timeout is reached when there are connection issues.
+     *
+     * @return RequestConfig
+     */
+    public RequestConfig getDVLAEndpointsRequestConfig() {
+        // RequestConfig is set per request for DVLA to apply the timeouts
+        // Only socket read maters if the HTTP client is able to re-use a connection
+        return RequestConfig.custom()
+                .setConnectionRequestTimeout(DVLA_HTTP_CONN_POOL_REQ_TIMEOUT_MS)
+                .setConnectTimeout(DVLA_HTTP_INITIAL_CONNECTION_TIMEOUT_MS)
+                .setSocketTimeout(DVLA_HTTP_SOCKET_READ_TIMEOUT_MS)
                 .build();
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Correct the IOException type that HttpRetryer will retry to match the ones thrown by the http client used.

### Why did it change

The HttpRetryer has the HttpConnectTimeoutException set as a retry condition this exception is not thrown by the HTTP client. 
This has been change to allow retrying a ConnectTimeoutException or SocketTimeoutException.

For DVLA the retry has been lowered to 1 per endpoint (token/match)
The timeout values have been adjusted to be within the lambda timeout period but to allow the worst case of 1 retry for each endpoint with a slow but successful response on the retry.

### Issue tracking

- [LIME-909](https://govukverify.atlassian.net/browse/LIME-909)
- [LIME-889](https://govukverify.atlassian.net/browse/LIME-889)