### PR TITLE
LIME-768 Implement recovery for token expiration during use

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
@@ -105,7 +105,7 @@ Feature: DrivingLicence CRI API
     Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
     Examples:
       |PassportJsonPayload         | jsonEdits                                                                  | cri_internal_error_code | cri_internal_error_message                                  |
-      |DVLAValidKennethJsonPayload | {"surname": "Unauthorized", "drivingLicenceNumber" : "UNAUT123456AB1AB"}   | 1314                    | error match endpoint returned unexpected http status code   |
+      |DVLAValidKennethJsonPayload | {"surname": "Unauthorized", "drivingLicenceNumber" : "UNAUT123456AB1AB"}   | 1316                    | error dvla expired token recovery failed                    |
       |DVLAValidKennethJsonPayload | {"surname": "Forbidden", "drivingLicenceNumber" : "FORBI123456AB1AB"}      | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "CannotBeFound", "drivingLicenceNumber" : "CANNO123456AB1AB"}  | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "TooManyRequest", "drivingLicenceNumber" : "TOOMA123456AB1AB"} | 1314                    | error match endpoint returned unexpected http status code   |

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaThirdPartyDocumentGateway.java
@@ -2,18 +2,21 @@ package uk.gov.di.ipv.cri.drivingpermit.api.service.dvla;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckResult;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.result.APIResultSource;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIService;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.domain.response.Validity;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.domain.result.DriverMatchServiceResult;
+import uk.gov.di.ipv.cri.drivingpermit.library.dvla.exception.DVLAMatchUnauthorizedException;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.DvlaEndpointFactory;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.endpoints.DriverMatchService;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.endpoints.TokenRequestService;
 import uk.gov.di.ipv.cri.drivingpermit.library.exceptions.OAuthErrorResponseException;
 
 import static uk.gov.di.ipv.cri.drivingpermit.api.domain.result.APIResultSource.DVLA;
+import static uk.gov.di.ipv.cri.drivingpermit.library.error.ErrorResponse.ERROR_DVLA_EXPIRED_TOKEN_RECOVERY_FAILED;
 
 public class DvlaThirdPartyDocumentGateway implements ThirdPartyAPIService {
 
@@ -24,6 +27,8 @@ public class DvlaThirdPartyDocumentGateway implements ThirdPartyAPIService {
 
     private final TokenRequestService tokenRequestService;
     private final DriverMatchService driverMatchService;
+
+    private static final int MAX_UNAUTHORIZED_RECOVERY_ATTEMPTS = 1;
 
     public DvlaThirdPartyDocumentGateway(DvlaEndpointFactory endpointFactory) {
         tokenRequestService = endpointFactory.getTokenRequestService();
@@ -39,18 +44,63 @@ public class DvlaThirdPartyDocumentGateway implements ThirdPartyAPIService {
     public DocumentCheckResult performDocumentCheck(DrivingPermitForm drivingPermitForm)
             throws OAuthErrorResponseException {
 
-        String tokenValue = tokenRequestService.requestToken(false);
+        LOGGER.info("DVLA request started");
 
-        LOGGER.info("Token value {}", tokenValue);
+        DriverMatchServiceResult driverMatchServiceResult = null;
 
-        DriverMatchServiceResult driverMatchServiceResult =
-                driverMatchService.performMatch(drivingPermitForm, tokenValue);
+        // Use any existing token by default
+        boolean newTokenOverride = false;
+
+        // Only happy path becomes true
+        boolean finished = false;
+
+        // > 0 are token expired recovery iterations
+        int iteration = 0;
+
+        do {
+            String tokenValue = tokenRequestService.requestToken(newTokenOverride);
+
+            LOGGER.info("Token value {}", tokenValue);
+
+            try {
+                driverMatchServiceResult =
+                        driverMatchService.performMatch(drivingPermitForm, tokenValue);
+
+                finished = true;
+
+            } catch (DVLAMatchUnauthorizedException e) {
+
+                LOGGER.warn("{} - iteration {}", e.getClass().getSimpleName(), iteration);
+
+                if (iteration == MAX_UNAUTHORIZED_RECOVERY_ATTEMPTS) {
+
+                    // If Unauthorized comes back again, there could be an issue with the api key
+                    LOGGER.error(ERROR_DVLA_EXPIRED_TOKEN_RECOVERY_FAILED);
+
+                    throw new OAuthErrorResponseException(
+                            HttpStatusCode.INTERNAL_SERVER_ERROR,
+                            ERROR_DVLA_EXPIRED_TOKEN_RECOVERY_FAILED);
+                } else {
+                    LOGGER.warn(
+                            "Assuming Token expired, attempting recovery via a new token request");
+
+                    // flip flag to force update the token
+                    newTokenOverride = true;
+                    iteration++;
+                }
+            }
+
+        } while (!finished);
+
+        LOGGER.info("DVLA request complete");
 
         return mapDriverMatchServiceResultToDocumentCheckResult(driverMatchServiceResult);
     }
 
     private static DocumentCheckResult mapDriverMatchServiceResultToDocumentCheckResult(
             DriverMatchServiceResult driverMatchServiceResult) {
+
+        LOGGER.info("Mapping DVLA response");
 
         // Validity.NOT_FOUND and Validity.INVALID map as false here
         boolean validDocument = (driverMatchServiceResult.getValidity() == Validity.VALID);

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/RequestSentAuditHelper.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/RequestSentAuditHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.util;
 
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
@@ -17,6 +18,11 @@ import java.util.Objects;
 import static uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority.DVLA;
 
 public class RequestSentAuditHelper {
+
+    @ExcludeFromGeneratedCoverageReport
+    private RequestSentAuditHelper() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
 
     public static PersonIdentityDetailed drivingPermitFormDataToAuditRestrictedFormat(
             DrivingPermitForm drivingPermitData) {

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dvla/DvlaThirdPartyDocumentGatewayTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.service.dvla;
 
+import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,17 +12,22 @@ import uk.gov.di.ipv.cri.drivingpermit.api.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIService;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.domain.response.Validity;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.domain.result.DriverMatchServiceResult;
+import uk.gov.di.ipv.cri.drivingpermit.library.dvla.exception.DVLAMatchUnauthorizedException;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.DvlaEndpointFactory;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.endpoints.DriverMatchService;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.service.endpoints.TokenRequestService;
+import uk.gov.di.ipv.cri.drivingpermit.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.drivingpermit.library.exceptions.OAuthErrorResponseException;
 import uk.gov.di.ipv.cri.drivingpermit.util.DrivingPermitFormTestDataGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.drivingpermit.api.domain.result.APIResultSource.DVLA;
+import static uk.gov.di.ipv.cri.drivingpermit.library.error.ErrorResponse.ERROR_MATCH_ENDPOINT_REJECTED_TOKEN_OR_API_KEY;
 
 @ExtendWith(MockitoExtension.class)
 class DvlaThirdPartyDocumentGatewayTest {
@@ -78,5 +84,74 @@ class DvlaThirdPartyDocumentGatewayTest {
         assertNotNull(result.getTransactionId());
         assertEquals(expectedIsValid, result.isValid());
         assertEquals(DVLA, result.getApiResultSource());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "true", // RecoverySuccessful after a 401 from match
+        "false", // RecoveryFail - match still has a 401 on the second attempt
+    })
+    void shouldAttemptRecovery(boolean recoverySucessful) throws OAuthErrorResponseException {
+
+        DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
+
+        // Token Value
+        String testTokenValue = "TEST_TOKEN_VALUE";
+
+        // Generated a valid api response object to create the api response for this test
+        DriverMatchServiceResult testDriverMatchServiceResult =
+                DriverMatchServiceResult.builder()
+                        .validity(Validity.VALID)
+                        .requestId("123456")
+                        .build();
+
+        when(mockTokenRequestService.requestToken(any(Boolean.class)))
+                .thenReturn(testTokenValue)
+                .thenReturn(testTokenValue); // second request
+
+        DVLAMatchUnauthorizedException exceptionCaught =
+                new DVLAMatchUnauthorizedException(
+                        ERROR_MATCH_ENDPOINT_REJECTED_TOKEN_OR_API_KEY.getMessage());
+
+        // Using the correct third party API?
+        assertEquals(
+                dvlaThirdPartyAPIService.getServiceName(),
+                DvlaThirdPartyDocumentGateway.class.getSimpleName());
+
+        if (recoverySucessful) {
+            // Match issue resolved via new token
+            when(mockDriverMatchService.performMatch(drivingPermitForm, testTokenValue))
+                    .thenThrow(exceptionCaught)
+                    .thenReturn(testDriverMatchServiceResult);
+
+            DocumentCheckResult result =
+                    dvlaThirdPartyAPIService.performDocumentCheck(drivingPermitForm);
+
+            assertNotNull(result);
+            assertNotNull(result.getTransactionId());
+            assertTrue(result.isValid());
+            assertEquals(DVLA, result.getApiResultSource());
+        } else {
+            // Match issue remains
+            when(mockDriverMatchService.performMatch(drivingPermitForm, testTokenValue))
+                    .thenThrow(exceptionCaught)
+                    .thenThrow(exceptionCaught);
+
+            OAuthErrorResponseException expectedReturnedException =
+                    new OAuthErrorResponseException(
+                            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                            ErrorResponse.ERROR_DVLA_EXPIRED_TOKEN_RECOVERY_FAILED);
+
+            OAuthErrorResponseException thrownException =
+                    assertThrows(
+                            OAuthErrorResponseException.class,
+                            () -> dvlaThirdPartyAPIService.performDocumentCheck(drivingPermitForm),
+                            "Expected OAuthErrorResponseException");
+
+            assertEquals(
+                    expectedReturnedException.getStatusCode(), thrownException.getStatusCode());
+            assertEquals(
+                    expectedReturnedException.getErrorReason(), thrownException.getErrorReason());
+        }
     }
 }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/RequestSentAuditHelperTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/RequestSentAuditHelperTest.java
@@ -2,12 +2,15 @@ package uk.gov.di.ipv.cri.drivingpermit.api.util;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.DrivingPermit;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DrivingPermitForm;
+import uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority;
 import uk.gov.di.ipv.cri.drivingpermit.util.DrivingPermitFormTestDataGenerator;
 
 import java.util.ArrayList;
@@ -19,10 +22,16 @@ import static uk.gov.di.ipv.cri.drivingpermit.library.config.GlobalConstants.UK_
 @ExtendWith(MockitoExtension.class)
 class RequestSentAuditHelperTest {
 
-    @Test
-    void ShouldReturnAuditRestrictedFormatFromDrivingPermitFormData() {
+    @ParameterizedTest
+    @CsvSource({
+        "DVA", // IssuingAuthority
+        "DVLA",
+    })
+    void ShouldReturnAuditRestrictedFormatFromDrivingPermitFormData(
+            IssuingAuthority issuingAuthority) {
 
-        DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
+        DrivingPermitForm drivingPermitForm =
+                DrivingPermitFormTestDataGenerator.generate(issuingAuthority);
 
         PersonIdentityDetailed testPersonIdentityDetailedFromFormData =
                 RequestSentAuditHelper.drivingPermitFormDataToAuditRestrictedFormat(

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.util;
 
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.verifiablecredential.Evidence;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.verifiablecredential.EvidenceType;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.CheckDetails;
@@ -9,6 +10,7 @@ import java.util.List;
 
 public class EvidenceHelper {
 
+    @ExcludeFromGeneratedCoverageReport
     private EvidenceHelper() {
         throw new IllegalStateException("Instantiation is not valid for this class.");
     }

--- a/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/exception/DVLAMatchUnauthorizedException.java
+++ b/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/exception/DVLAMatchUnauthorizedException.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.cri.drivingpermit.library.dvla.exception;
+
+public class DVLAMatchUnauthorizedException extends RuntimeException {
+    public DVLAMatchUnauthorizedException(String message) {
+        super(message);
+    }
+
+    // Lowers over head of the exception by suppressing creation of the stack trace
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/endpoints/TokenRequestService.java
+++ b/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/endpoints/TokenRequestService.java
@@ -120,7 +120,7 @@ public class TokenRequestService {
                 tokenTtlHasExpired);
 
         if (alwaysRequestNewToken) {
-            LOGGER.info("Override enabled - always requesting a new token");
+            LOGGER.info("Override enabled - requesting a new token");
         }
 
         boolean newTokenRequest =

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/error/ErrorResponse.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/error/ErrorResponse.java
@@ -46,7 +46,7 @@ public enum ErrorResponse {
     ERROR_TOKEN_ENDPOINT_RETURNED_UNEXPECTED_HTTP_STATUS_CODE(
             1307, "token endpoint returned unexpected http status code"),
     ERROR_INVOKING_THIRD_PARTY_API_MATCH_ENDPOINT(
-            1308, "error_invoking_third_party_api_match_endpoint"),
+            1308, "error invoking third party api match endpoint"),
     FAILED_TO_PREPARE_MATCH_REQUEST_PAYLOAD(1310, "failed to prepare match request payload"),
     FAILED_TO_MAP_MATCH_ENDPOINT_RESPONSE_BODY(1311, "failed to map match endpoint response_body"),
     MATCH_ENDPOINT_404_RESPONSE_EXPECTED_ERROR_SIZE_NOT_ONE(
@@ -54,7 +54,10 @@ public enum ErrorResponse {
     MATCH_ENDPOINT_404_RESPONSE_EXPECTED_ERROR_CODE_NOT_CORRECT(
             1313, "match endpoint 404 response expected error code not correct"),
     ERROR_MATCH_ENDPOINT_RETURNED_UNEXPECTED_HTTP_STATUS_CODE(
-            1314, "error match endpoint returned unexpected http status code");
+            1314, "error match endpoint returned unexpected http status code"),
+    ERROR_MATCH_ENDPOINT_REJECTED_TOKEN_OR_API_KEY(
+            1315, "error match endpoint rejected token or api key"),
+    ERROR_DVLA_EXPIRED_TOKEN_RECOVERY_FAILED(1316, "error dvla expired token recovery failed");
 
     private final int code;
     private final String message;


### PR DESCRIPTION
## Proposed changes

### What changed

Added handling of an edge case where a token may have been invalidated remotely before the expected expiration time.
Should this happen a recovery mechanism will attempt to retrieve a new token and make one more match attempt.

### Why did it change

To avoid failing the users attempt, should this occur at the inopportune time of the token being invalidated while being used in a match request.

### Issue tracking

- [LIME-768](https://govukverify.atlassian.net/browse/LIME-768)

[LIME-768]: https://govukverify.atlassian.net/browse/LIME-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ