### PR TITLE
LIME-727 Increase DL API Throttle/Throttling limits

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -166,10 +166,10 @@ Mappings:
   MemorySizeMapping:
     Environment:
       dev: 2048
-      build: 3072
-      staging: 3072
-      integration: 3072
-      production: 3072
+      build: 4096
+      staging: 2048
+      integration: 2048
+      production: 4096
 
   MaxJwtTtlMapping:
     Environment:
@@ -256,8 +256,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicDrivingPermitApiAccessLogGroup}'
         Format: >-
@@ -352,8 +352,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateDrivingPermitApiAccessLogGroup}'
         Format: >-
@@ -754,8 +754,8 @@ Resources:
         Limit: 500000
         Period: DAY
       Throttle:
-        BurstLimit: 100 # requests the API can handle concurrently
-        RateLimit: 50 # allowed requests per second
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
 
   PrivateDrivingPermitApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -770,8 +770,8 @@ Resources:
         Limit: 500000
         Period: DAY
       Throttle:
-        BurstLimit: 100 # requests the API can handle concurrently
-        RateLimit: 50 # allowed requests per second
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
 
   LinkUsagePlanApiKey1:
     Type: AWS::ApiGateway::UsagePlanKey


### PR DESCRIPTION
## Proposed changes

### What changed

Increase api rate/burst limits and lambda cpu allocation

### Why did it change

API limits increased to match address-ap/core-back as a fix is being prepared in dl-front that should enable front autoscaling, which should have an increase in traffic against both private/public apis.

### Issue tracking

- [LIME-727](https://govukverify.atlassian.net/browse/LIME-727)

[LIME-727]: https://govukverify.atlassian.net/browse/LIME-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ