### PR TITLE
LIME-844 Update ac test image to JDK17 and Gradle8

### DIFF
--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -1,4 +1,7 @@
-FROM gradle:7.6.0-jdk11
+FROM gradle:8.1.1-jdk17
+# The following will allow you to test building the amd64 image on an arm64 mac
+# DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build --tag 'dl-ac-test-image' .
+
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
 RUN apt-get update
@@ -11,6 +14,7 @@ RUN apt-get -y install dbus-x11 xfonts-base xfonts-100dpi xfonts-75dpi xfonts-cy
 RUN apt-get -y install libxss1 lsb-release xdg-utils
 RUN apt-get -y install jq
 
+# Chrome not available for arm64 linux currently and we want to use chrome not chromium
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg --configure -a
 RUN dpkg -i --force-depends google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
## Proposed changes

### What changed

Update ac test image to JDK17 and Gradle8

### Why did it change

The pipeline test step is attempting to use gradle7.6 and jdk11 for the ac tests.

### Issue tracking

- [LIME-844](https://govukverify.atlassian.net/browse/LIME-844)


[LIME-844]: https://govukverify.atlassian.net/browse/LIME-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ