### PR TITLE
LIME-769: Updating secret rotation to not happen on deployment or secret change and toggled off implementation in integration and prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -222,8 +222,8 @@ Mappings:
       dev: "true"
       build: "true"
       staging: "true"
-      integration: "true"
-      production: "true"
+      integration: "false"
+      production: "false"
 
   dvlaPasswordRotationWindow:
     Environment:
@@ -715,6 +715,7 @@ Resources:
     DependsOn:
       - PasswordRenewalFunctionPermission
     Properties:
+      RotateImmediatelyOnUpdate: false
       SecretId: !Ref DVLAPasswordSecret
       RotationLambdaARN: !GetAtt PasswordRenewalFunction.Arn
       RotationRules:
@@ -1044,7 +1045,12 @@ Resources:
     Type: 'AWS::SecretsManager::Secret'
     Properties:
       Name: !Sub "/${AWS::StackName}/DVLA/password"
-      Description: This is a temp password used before the roation function is applied. Checking if update triggers rotation
+      SecretString:
+        !Sub
+          - '{{resolve:ssm:/${PREFIX}/DVLA/password}}'
+          - PREFIX: !If [ UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName ]
+
+      Description: This is a temp password used before the rotation function is applied. Checking if update triggers rotation
 
   LoggingKmsKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
## Proposed changes

### What changed

Updated the template so that the initial secret value is read from the param and so that the rotation does not happen immediately in higher envs

### Why did it change

To allow the release and secret rotation to be decoupled

### Issue tracking

- [LIME-769](https://govukverify.atlassian.net/browse/LIME-769)



[LIME-769]: https://govukverify.atlassian.net/browse/LIME-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ