### PR TITLE
LIME-569 adding jti field to VC

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.sendHttpRequest;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -253,6 +254,18 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         String drivingLicenceCRIVC = postRequestToDrivingLicenceVCEndpoint();
         assertCheckDetailsWithinVc(
                 checkMethod, identityCheckPolicy, checkDetailsType, drivingLicenceCRIVC);
+    }
+
+    public void assertJtiIsPresentAndNotNull()
+            throws IOException, ParseException, InterruptedException {
+        String result = postRequestToDrivingLicenceVCEndpoint();
+        LOGGER.info("result = " + result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        JsonNode jtiNode = jsonNode.get("jti");
+        LOGGER.info("jti = " + jtiNode.asText());
+
+        assertNotNull(jtiNode.asText());
     }
 
     private String getClaimsForUser(String baseUrl, String criId, int userDataRowNumber)

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -29,6 +29,7 @@ import static gov.di_ipv_drivingpermit.pages.Headers.IPV_CORE_STUB;
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 import static java.lang.System.getenv;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -932,6 +933,14 @@ public class DrivingLicencePageObject extends UniversalSteps {
         JsonNode vcNode = getJsonNode(result, "vc");
         String licenceNumber = getPersonalNumberFromVc(vcNode);
         assertEquals(personalNumber, licenceNumber);
+    }
+
+    public void assertJtiPresent() throws IOException {
+        String result = JSONPayload.getText();
+        LOGGER.info("result = " + result);
+        JsonNode jtiNode = getJsonNode(result, "jti");
+        String jti = jtiNode.asText();
+        assertNotNull(jti);
     }
 
     public void validateErrorPageHeading(String errorHeading) {

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -198,6 +198,11 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
         new DrivingLicencePageObject().assertPersonalNumberInVc(personalNumber);
     }
 
+    @And("JSON response should contain JTI field")
+    public void JtiFieldInResponse() throws IOException {
+        assertJtiPresent();
+    }
+
     @When("^DVLA consent checkbox is unselected$")
     public void dvla_consent_checkbox_click() {
         consentDVLACheckbox.click();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceAPIStepDefs.java
@@ -66,6 +66,12 @@ public class DrivingLicenceAPIStepDefs extends DrivingLicenceAPIPage {
         validityScoreAndStrengthScoreInVC(validityScore, strengthScore);
     }
 
+    @And("^Driving Licence VC should contain JTI field$")
+    public void jsonPayloadShouldContainJtiField()
+            throws IOException, ParseException, InterruptedException {
+        assertJtiIsPresentAndNotNull();
+    }
+
     @When(
             "Driving Licence user sends a editable POST request to Driving Licence endpoint using jsonRequest (.*) with edited fields (.*)$")
     public void passport_user_sends_a_post_request_to_passport_end_point(

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -17,6 +17,7 @@ Feature: DVA Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number 55667788 same as given Driving Licence
+    And JSON response should contain JTI field
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject             |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicenceCRIAPI.feature
@@ -13,6 +13,7 @@ Feature: DrivingLicence CRI API
     Then User requests Driving Licence CRI VC
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+    And Driving Licence VC should contain JTI field
 
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario: DVLA Password rotation check

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
 ext {
 	dependencyVersions = [
 		// Implementation
-		cri_common_lib_version             : "1.5.0",
+		cri_common_lib_version             : "1.5.4",
 		nimbusds_oauth_version             : "10.8",
 		nimbusds_jwt_version               : "9.31",
 		aws_sdk_version                    : "2.20.18",

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -183,6 +183,14 @@ Mappings:
       integration: "true"
       production: "true"
 
+  VcContainsUniqueIdMapping:
+    Environment:
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "true"
+      production: "true"
+
   JwtTtlUnitMapping:
     Environment:
       dev: MONTHS
@@ -600,6 +608,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow
@@ -920,6 +929,14 @@ Resources:
       Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
       Type: String
       Description: Expiry date release toggle
+
+  ReleaseFlagsVcContainsUniqueIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
+      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Type: String
+      Description: Verifiable Credential Contains UniqueId Mapping
 
   ParameterDocumentCheckResultTableName:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Enabling JTI token field to appear in VC, and adding this check to acceptance checks.

### Why did it change

To align with other CRIs and enable use of JTI for unique referencing.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-569](https://govukverify.atlassian.net/browse/LIME-569)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-569]: https://govukverify.atlassian.net/browse/LIME-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ