### PR TITLE
added @stub and @uat tags and removed unnecessary tags

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
@@ -10,7 +10,7 @@ Feature: Driving License Test Common
     Then I see the message begins with We need to make sure is shown
     And I assert the url path contains licence-issuer
 
-  @DrivingLicenceTest @build @staging @integration @smoke
+  @DrivingLicenceTest @build @staging @integration @smoke @stub
   Scenario:3 options and Radio button available in Driving Licence page
     Given I can see a DVLA radio button titled DVLA
     Then I can see a DVA radio button titled DVA
@@ -18,7 +18,7 @@ Feature: Driving License Test Common
     Then I can see CTA Continue
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest @build @staging @integration @smoke
+  @DrivingLicenceTest @build @staging @integration @smoke @stub
   Scenario: Beta Banner Reject Analysis
     When I view the Beta banner
     When the beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
@@ -37,7 +37,7 @@ Feature: Driving License Test Common
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest @build @staging @integration
+  @DrivingLicenceTest @build @staging @integration @stub
   Scenario: User continue with no selection and see the error displayed
     Given I have not selected anything and Continue
     When I can see an error box highlighted red
@@ -46,7 +46,7 @@ Feature: Driving License Test Common
     And The field error copy Error:You must choose an option to continue
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest @build @staging @integration
+  @DrivingLicenceTest @build @staging @integration @stub
   Scenario: Check the Unrecoverable error/ Unknown error in Driving Licence CRI
     Given I delete the service_session cookie to get the unexpected error
     When I check the page title is Sorry, there is a problem – Prove your identity – GOV.UK

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -10,7 +10,7 @@ Feature: DVA Driving Licence Test
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     And I see a form requesting DVA LicenceNumber
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVA - Happy path
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -34,7 +34,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |DVADrivingLicenceSubjectUnhappySelina |
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid driving licence number
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -48,7 +48,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |IncorrectDrivingLicenceNumber |
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid date of birth and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -61,7 +61,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDateOfBirth |
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid first name and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -74,7 +74,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectFirstName|
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid last name and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -87,7 +87,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectLastName|
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid issue date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -100,7 +100,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectIssueDate|
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid valid-to date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -113,7 +113,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectValidToDate|
 
-  @DVADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVA - User enters invalid postcode and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -127,7 +127,7 @@ Feature: DVA Driving Licence Test
       |IncorrectPostcode|
 
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -141,7 +141,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceSubjectHappyBilly |
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @stub @uat @smoke
   Scenario Outline: DVA - User attempts invalid journey and retries with invalid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -155,7 +155,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDrivingLicenceNumber |
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @stub @uat @smoke
   Scenario: DVA - User attempts invalid journey and cancels after first attempt
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -165,14 +165,14 @@ Feature: DVA Driving Licence Test
     And JSON payload should contain ci D02, validity score 0, strength score 3 and type IdentityCheck
     And The test is complete and I close the driver
 
-  @DVADrivingLicence_test @smoke
+  @smoke
   Scenario: DVA - User cancels before first attempt by clicking prove another way and returns an authorisation error
     Given User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVADrivingLicence_test @smoke
+  @smoke
   Scenario: DVA - User cancels before first attempt by clicking no driving licence and returns an authorisation error
     Given User click on ‘Back' Link
     When User click on I do not have a UK driving licence radio button
@@ -180,7 +180,7 @@ Feature: DVA Driving Licence Test
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVADrivingLicence_test @build
+  @build @stub
   Scenario Outline: DVA - User enters invalid details and returns enter your details as it appears error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -209,7 +209,7 @@ Feature: DVA Driving Licence Test
 
 ###########  DVA Field Validations ##########
     #not existing in front end repo
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @uat @stub
   Scenario: DVA - User consents to have DL checked and navigates to DVA privacy notice
     Then I see the DVA consent section Allow DVA to check your driving licence details
     And I see the Consent sentence in DVA page DVA needs your consent to check your driving licence details before you can continue. They will make sure your licence has not been cancelled or reported as lost or stolen.
@@ -219,7 +219,7 @@ Feature: DVA Driving Licence Test
     And The test is complete and I close the driver
 
       #not existing in front end repo
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVA - User attempts journey with invalid details and clicks on prove another way and generates a VC
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -231,7 +231,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject           |
       | IncorrectDrivingLicenceNumber     |
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVA - User attempts journey with consent checkbox unselected and returns error
     Given User enters DVA data as a <DrivingLicenceSubject>
     And DVA consent checkbox is unselected
@@ -243,7 +243,7 @@ Feature: DVA Driving Licence Test
       |DrivingLicenceSubject             |
       |DVADrivingLicenceSubjectHappyBilly|
 
-  @DVADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario: DVA - User consents to have DL checked and navigates to DVA privacy notice
     Then I see the DVA consent section Allow DVA to check your driving licence details
     And I see the Consent sentence in DVA page DVA needs your consent to check your driving licence details before you can continue. They will make sure your licence has not been cancelled or reported as lost or stolen.

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
@@ -10,7 +10,7 @@ Feature: Driving Licence Test
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     And I see a form requesting DVLA LicenceNumber
 
-  @DVLADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVLA - Happy path
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -22,7 +22,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             |
       | DrivingLicenceSubjectHappyKenneth |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid driving licence number
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -36,7 +36,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject         |
       | IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVLA - User enters driving licence number and date of birth in incorrect format which returns validation error
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -47,7 +47,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject               |
       | DrivingLicenceNumberWithNumericChar |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid date of birth and returns field validation error
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -58,7 +58,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject |
       | IncorrectDateOfBirth  |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid last name and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -71,7 +71,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject |
       | IncorrectLastName     |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid issue date and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -84,7 +84,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject |
       | IncorrectIssueDate    |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid valid-to date and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -97,7 +97,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject |
       | IncorrectValidToDate  |
 
-  @DVLADrivingLicence_test @build @staging @integration
+  @build @staging @integration @stub @uat
   Scenario Outline: DVLA - User enters invalid issue number and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -110,7 +110,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject |
       | IncorrectIssueNumber  |
 
-  @DVLADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVLA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -124,7 +124,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             |
       | DrivingLicenceSubjectHappyKenneth |
 
-  @DVLADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario Outline: DVLA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -138,7 +138,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject         |
       | IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build @staging @integration @smoke
+  @build @staging @integration @smoke @stub @uat
   Scenario: DVLA - User attempts invalid journey and cancels after first attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -148,14 +148,14 @@ Feature: Driving Licence Test
     And JSON payload should contain ci D02, validity score 0, strength score 3 and type IdentityCheck
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @smoke
+  @smoke
   Scenario: DVLA - User cancels before first attempt by clicking prove another way and returns an authorisation error
     Given User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @smoke
+  @smoke
   Scenario: DVLA - User cancels before first attempt by clicking no driving licence and returns an authorisation error
     Given User click on ‘Back' Link
     When User click on I do not have a UK driving licence radio button
@@ -163,7 +163,7 @@ Feature: Driving Licence Test
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @build
+  @build @stub
   Scenario: DVLA - Password rotation check
     Given User enters DVLA data as a DrivingLicenceSubjectHappyKenneth
     When User clicks on continue
@@ -171,7 +171,7 @@ Feature: Driving Licence Test
     Then The secret has been created
     Then The DVLA password should be valid and rotated within the specified window
 
-  @DVLADrivingLicence_test @build
+  @build @stub
   Scenario Outline: DVLA - User enters invalid details and returns enter your details as it appears error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -202,7 +202,7 @@ Feature: Driving Licence Test
 
     ###########  DVLA Field Validations ##########
   #not existing in front end repo
-  @DVLADrivingLicence_test @build @staging @integration @dvlaDirect @cat
+  @build @staging @integration @dvlaDirect @stub @uat
   Scenario: DVLA - User consents to have DL checked and navigates to DVLA privacy notice
     Then I see the consent section Allow DVLA to check your driving licence details
     And I see the sentence DVLA needs your consent to check your driving licence details before you can continue. They will make sure your licence has not been cancelled or reported as lost or stolen.


### PR DESCRIPTION

### What changed

Added `@stub` and `@uat` tags
removed unnecessary tags

### Why did it change

As part of the E2E Test Data Strategy initiative. 

It covers updating our DVLA DL CRI test tags, so we are swapping build and staging. This is part of a programme push to have stubs in staging, and to have UAT in build.

### Issue tracking

- [LIME-976](https://govukverify.atlassian.net/browse/LIME-976)


[LIME-976]: https://govukverify.atlassian.net/browse/LIME-976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ