### PR TITLE
LIME-1069 aligning lng cookie value in tests

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/BrowserUtils.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/BrowserUtils.java
@@ -425,7 +425,7 @@ public class BrowserUtils {
         }
 
         String currentURL = Driver.get().getCurrentUrl();
-        String newURL = currentURL + "/?lang=" + languageCode;
+        String newURL = currentURL + "/?lng=" + languageCode;
         Driver.get().get(newURL);
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The value of "lang" has been edited to "lng" in acceptance-tests.

### Why did it change

The value has been changed in common-express. As our front end was changed for the language toggle, this change is required for our api tests to be aligned for this value.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1069](https://govukverify.atlassian.net/browse/LIME-1069)