### PR TITLE
LIME-1115 - Add ClientID to Driving Licence API Page for API Tests

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -239,7 +239,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
     }
 
     public void validityScoreAndStrengthScoreInVC(String validityScore, String strengthScore)
-            throws IOException, InterruptedException, ParseException {
+            throws IOException {
         scoreIs(validityScore, strengthScore, VC);
     }
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -87,7 +87,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         Map<String, String> deserialisedSessionResponse =
                 objectMapper.readValue(SESSION_REQUEST_BODY, new TypeReference<>() {});
         CLIENT_ID = deserialisedSessionResponse.get("client_id");
-        LOGGER.info("CLIENT_ID = " + CLIENT_ID);
+        LOGGER.info("CLIENT_ID = {}" + CLIENT_ID);
     }
 
     public void dlPostRequestToSessionEndpoint() throws IOException, InterruptedException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -78,10 +78,10 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
     public void dlUserIdentityAsJwtString(String criId, Integer rowNumber)
             throws URISyntaxException, IOException, InterruptedException {
         String jsonString = getAuthorisationJwtFromStub(criId, rowNumber);
-        LOGGER.info("jsonString = " + jsonString);
+        LOGGER.info("jsonString = {}", jsonString);
         String coreStubUrl = configurationService.getCoreStubUrl(false);
         SESSION_REQUEST_BODY = createRequest(coreStubUrl, criId, jsonString);
-        LOGGER.info("SESSION_REQUEST_BODY = " + SESSION_REQUEST_BODY);
+        LOGGER.info("SESSION_REQUEST_BODY = {}", SESSION_REQUEST_BODY);
 
         // Capture client id for using later in the auth request
         Map<String, String> deserialisedSessionResponse =
@@ -92,7 +92,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
 
     public void dlPostRequestToSessionEndpoint() throws IOException, InterruptedException {
         String privateApiGatewayUrl = configurationService.getPrivateAPIEndpoint();
-        LOGGER.info("getPrivateAPIEndpoint() ==> " + privateApiGatewayUrl);
+        LOGGER.info("getPrivateAPIEndpoint() ==> {}", privateApiGatewayUrl);
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(URI.create(privateApiGatewayUrl + "/session"))
@@ -102,7 +102,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                         .POST(HttpRequest.BodyPublishers.ofString(SESSION_REQUEST_BODY))
                         .build();
         String sessionResponse = sendHttpRequest(request).body();
-        LOGGER.info("sessionResponse = " + sessionResponse);
+        LOGGER.info("sessionResponse = {}", sessionResponse);
         Map<String, String> deserialisedResponse =
                 objectMapper.readValue(sessionResponse, new TypeReference<>() {});
         SESSION_ID = deserialisedResponse.get("session_id");
@@ -115,7 +115,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
     }
 
     public void getSessionIdForDL() {
-        LOGGER.info("SESSION_ID = " + SESSION_ID);
+        LOGGER.info("SESSION_ID = {}", SESSION_ID);
         assertTrue(StringUtils.isNotBlank(SESSION_ID));
     }
 
@@ -154,13 +154,13 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                         .setHeader("Content-Type", "application/json")
                         .setHeader("session_id", SESSION_ID)
                         .POST(HttpRequest.BodyPublishers.ofString(drivingPermitInputJsonString));
-        LOGGER.info("drivingLicenceRequestBody = " + dlInputJsonString);
+        LOGGER.info("drivingLicenceRequestBody = {}", dlInputJsonString);
         DRIVING_LICENCE_CHECK_RESPONSE = sendHttpRequest(request.build()).body();
-        LOGGER.info("drivingLicenceCheckResponse = " + DRIVING_LICENCE_CHECK_RESPONSE);
+        LOGGER.info("drivingLicenceCheckResponse = {}", DRIVING_LICENCE_CHECK_RESPONSE);
         DocumentCheckResponse documentCheckResponse =
                 objectMapper.readValue(DRIVING_LICENCE_CHECK_RESPONSE, DocumentCheckResponse.class);
         RETRY = documentCheckResponse.getRetry();
-        LOGGER.info("RETRY = " + RETRY);
+        LOGGER.info("RETRY = {}", RETRY);
     }
 
     public void postRequestToDrivingLicenceEndpoint(String drivingPermitJsonRequestBody)
@@ -193,21 +193,21 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                         .GET()
                         .build();
         String authCallResponse = sendHttpRequest(request).body();
-        LOGGER.info("authCallResponse = " + authCallResponse);
+        LOGGER.info("authCallResponse = {}", authCallResponse);
         AuthorisationResponse deserialisedResponse =
                 objectMapper.readValue(authCallResponse, AuthorisationResponse.class);
         if (null != deserialisedResponse.getAuthorizationCode()) {
             AUTHCODE = deserialisedResponse.getAuthorizationCode().getValue();
-            LOGGER.info("authorizationCode = " + AUTHCODE);
+            LOGGER.info("authorizationCode = {}", AUTHCODE);
         }
     }
 
     public void postRequestToAccessTokenEndpointForDL(String criId)
             throws IOException, InterruptedException {
         String accessTokenRequestBody = getAccessTokenRequest(criId);
-        LOGGER.info("Access Token Request Body = " + accessTokenRequestBody);
+        LOGGER.info("Access Token Request Body = {}", accessTokenRequestBody);
         String publicApiGatewayUrl = configurationService.getPublicAPIEndpoint();
-        LOGGER.info("getPublicAPIEndpoint() ==> " + publicApiGatewayUrl);
+        LOGGER.info("getPublicAPIEndpoint() ==> {}", publicApiGatewayUrl);
         HttpRequest request =
                 HttpRequest.newBuilder()
                         .uri(URI.create(publicApiGatewayUrl + "/token"))
@@ -216,7 +216,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                         .POST(HttpRequest.BodyPublishers.ofString(accessTokenRequestBody))
                         .build();
         String accessTokenPostCallResponse = sendHttpRequest(request).body();
-        LOGGER.info("accessTokenPostCallResponse = " + accessTokenPostCallResponse);
+        LOGGER.info("accessTokenPostCallResponse = {}", accessTokenPostCallResponse);
         Map<String, String> deserialisedResponse =
                 objectMapper.readValue(accessTokenPostCallResponse, new TypeReference<>() {});
         ACCESS_TOKEN = deserialisedResponse.get("access_token");
@@ -234,7 +234,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                         .POST(HttpRequest.BodyPublishers.ofString(""))
                         .build();
         String requestDrivingLicenceVCResponse = sendHttpRequest(request).body();
-        LOGGER.info("requestDrivingLicenceVCResponse = " + requestDrivingLicenceVCResponse);
+        LOGGER.info("requestDrivingLicenceVCResponse = {}", requestDrivingLicenceVCResponse);
         VC = SignedJWT.parse(requestDrivingLicenceVCResponse).getJWTClaimsSet().toString();
     }
 
@@ -247,7 +247,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         JsonNode jsonNode = objectMapper.readTree(VC);
         JsonNode evidenceArray = jsonNode.get("vc").get("evidence");
         JsonNode ciInEvidenceArray = evidenceArray.get(0);
-        LOGGER.info("ciInEvidenceArray = " + ciInEvidenceArray);
+        LOGGER.info("ciInEvidenceArray = {}", ciInEvidenceArray);
         JsonNode ciNode = ciInEvidenceArray.get("ci").get(0);
         String actualCI = ciNode.asText();
         Assert.assertEquals(ci, actualCI);
@@ -260,11 +260,11 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
     }
 
     public void assertJtiIsPresentAndNotNull() throws IOException {
-        LOGGER.info("result = " + VC);
+        LOGGER.info("result = {}", VC);
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(VC);
         JsonNode jtiNode = jsonNode.get("jti");
-        LOGGER.info("jti = " + jtiNode.asText());
+        LOGGER.info("jti = {}", jtiNode.asText());
 
         assertNotNull(jtiNode.asText());
     }
@@ -280,7 +280,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                                 + "&rowNumber="
                                 + userDataRowNumber);
 
-        LOGGER.info("URL =>> " + url);
+        LOGGER.info("URL =>> {}", url);
 
         HttpRequest request =
                 HttpRequest.newBuilder()

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -261,7 +261,6 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
 
     public void assertJtiIsPresentAndNotNull() throws IOException {
         LOGGER.info("result = {}", VC);
-        ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonNode = objectMapper.readTree(VC);
         JsonNode jtiNode = jsonNode.get("jti");
         LOGGER.info("jti = {}", jtiNode.asText());

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -87,7 +87,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         Map<String, String> deserialisedSessionResponse =
                 objectMapper.readValue(SESSION_REQUEST_BODY, new TypeReference<>() {});
         CLIENT_ID = deserialisedSessionResponse.get("client_id");
-        LOGGER.info("CLIENT_ID = {}" + CLIENT_ID);
+        LOGGER.info("CLIENT_ID = {}", CLIENT_ID);
     }
 
     public void dlPostRequestToSessionEndpoint() throws IOException, InterruptedException {
@@ -111,7 +111,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         Map<String, String> deserialisedSessionResponse =
                 objectMapper.readValue(SESSION_REQUEST_BODY, new TypeReference<>() {});
         CLIENT_ID = deserialisedSessionResponse.get("client_id");
-        LOGGER.info("CLIENT_ID = " + CLIENT_ID);
+        LOGGER.info("CLIENT_ID = {}", CLIENT_ID);
     }
 
     public void getSessionIdForDL() {


### PR DESCRIPTION
Updated DrivingLicenceAPIPage to use ClientID values

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1115] Updating Common-libs version in all CRIs` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Added the ClientID Value for Driving Licence API Tests

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
This captures the ClientId found in the session response and uses it in the later auth code request call

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1115](https://govukverify.atlassian.net/browse/LIME-1115)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-1115]: https://govukverify.atlassian.net/browse/LIME-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1115]: https://govukverify.atlassian.net/browse/LIME-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ