### PR TITLE
IPS-487: Add pre-commit GHA workflow and pre-commit-config

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -8,6 +8,22 @@ on:
       - synchronize
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Pre-commit github action
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: "detect-secrets --all-files"
+
   style-checks:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    - id: check-json
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: detect-aws-credentials
+      args: [ --allow-missing-credentials ]
+    - id: detect-private-key
+
+  - repo: https://github.com/awslabs/cfn-python-lint
+    rev: v1.2.5.a10 # The version of cfn-lint to use
+    hooks:
+    - id: cfn-python-lint
+      files: .template\.yaml$
+
+  - repo: https://github.com/bridgecrewio/checkov.git
+    rev: '3.2.138'
+    hooks:
+    - id: checkov
+      verbose: true
+      args: [--soft-fail]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+    - id: detect-secrets
+      args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,390 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "acceptance-tests/src/test/resources/axe.min.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "acceptance-tests/src/test/resources/axe.min.js",
+        "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_verified": false
+      }
+    ],
+    "infrastructure/lambda/public-api.yaml": [
+      {
+        "type": "JSON Web Token",
+        "filename": "infrastructure/lambda/public-api.yaml",
+        "hashed_secret": "01613fb1bb441c88d5e6773e2813ee026ad5b928",
+        "is_verified": false
+      },
+      {
+        "type": "JSON Web Token",
+        "filename": "infrastructure/lambda/public-api.yaml",
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_verified": false
+      }
+    ],
+    "infrastructure/lambda/template.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/lambda/template.yaml",
+        "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
+        "is_verified": false
+      }
+    ],
+    "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java",
+        "hashed_secret": "272b2480feac66400cb04c993c1f30eebcb85170",
+        "is_verified": false
+      }
+    ],
+    "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java",
+        "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java",
+        "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
+        "is_verified": false
+      }
+    ],
+    "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "095f47d22e20655016ead16e0264f994b0ef5323",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "3524aaa7f36b6a777ed767b1f2f3cc0512783810",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "76141ecdf327788c3f946f0d1a665cb945cff8ab",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java",
+        "hashed_secret": "dfd787252ff7385f31a57bddf4597e207b13fda7",
+        "is_verified": false
+      }
+    ],
+    "lambdas/passwordRenewal/src/test/java/uk/gov/di/ipv/cri/drivingpermit/event/endpoints/ChangePasswordServiceTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/passwordRenewal/src/test/java/uk/gov/di/ipv/cri/drivingpermit/event/endpoints/ChangePasswordServiceTest.java",
+        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "is_verified": false
+      }
+    ],
+    "lambdas/passwordRenewal/src/test/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandlerTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lambdas/passwordRenewal/src/test/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandlerTest.java",
+        "hashed_secret": "5fa339bbbb1eeaced3b52e54f44576aaf0d77d96",
+        "is_verified": false
+      }
+    ],
+    "lib-dva/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/service/DvaCryptographyServiceTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lib-dva/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/service/DvaCryptographyServiceTest.java",
+        "hashed_secret": "f8893bdfd4ef673221a46eef734ce906270210d2",
+        "is_verified": false
+      }
+    ],
+    "lib-dva/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/service/HashFactoryTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lib-dva/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/service/HashFactoryTest.java",
+        "hashed_secret": "bfbf6a93296ecf6cd7f433afb6b269ab7a5d9e9c",
+        "is_verified": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lib-dva/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/service/HashFactoryTest.java",
+        "hashed_secret": "f8893bdfd4ef673221a46eef734ce906270210d2",
+        "is_verified": false
+      }
+    ],
+    "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java",
+        "hashed_secret": "10e6b0f3a9fe855834eca1226b44376011557921",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java",
+        "hashed_secret": "3bff7544b01bd034a3090decdbba1a2a67ccc078",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java",
+        "hashed_secret": "c1c894ec3f58b114ced01432840a39e37bfa7511",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java",
+        "hashed_secret": "dc620e25f02856ddf327f15dd9d627b029e6e949",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib-dva/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/library/dva/KeyUtilities.java",
+        "hashed_secret": "e2347759b2721faaf15b859b67815419a497b596",
+        "is_verified": false
+      }
+    ],
+    "lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/domain/request/RequestHeaderKeys.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/domain/request/RequestHeaderKeys.java",
+        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
+        "is_verified": false
+      }
+    ],
+    "lib-dvla/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/endpoints/TokenRequestServiceTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lib-dvla/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/endpoints/TokenRequestServiceTest.java",
+        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "is_verified": false
+      }
+    ],
+    "lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java",
+        "hashed_secret": "395dcc8f5f5824acaaf6d0127adef4483c205919",
+        "is_verified": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java",
+        "hashed_secret": "fceb37a2ac68abc4535f3f3c1359ce5983414f7b",
+        "is_verified": false
+      }
+    ],
+    "lib/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/helpers/KeyCertHelperTest.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/helpers/KeyCertHelperTest.java",
+        "hashed_secret": "8e98bd491e3da79b478906631c4b4de4284419fa",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/helpers/KeyCertHelperTest.java",
+        "hashed_secret": "bfa1b54631f691aa9d9937866f6e21270fd7deec",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/test/java/uk/gov/di/ipv/cri/drivingpermit/library/helpers/KeyCertHelperTest.java",
+        "hashed_secret": "d88d322997ecae6606b7ddc508a142281b6e4c30",
+        "is_verified": false
+      }
+    ],
+    "lib/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/util/CertAndKeyTestFixtures.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/util/CertAndKeyTestFixtures.java",
+        "hashed_secret": "8e98bd491e3da79b478906631c4b4de4284419fa",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/util/CertAndKeyTestFixtures.java",
+        "hashed_secret": "bfa1b54631f691aa9d9937866f6e21270fd7deec",
+        "is_verified": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lib/src/testFixtures/java/uk/gov/di/ipv/cri/drivingpermit/util/CertAndKeyTestFixtures.java",
+        "hashed_secret": "d88d322997ecae6606b7ddc508a142281b6e4c30",
+        "is_verified": false
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,77 @@ Restart your terminal
 
 Gradle 8 is used on this project
 
+## Pre-Commit Checking / Verification
+
+Completely optional, there is a `.pre-commit-config.yaml` configuration setup in this repo, this uses [pre-commit](https://pre-commit.com/) to verify your commit before actually commiting, it runs the following checks:
+
+* Check Json files for formatting issues
+* Fixes end of file issues (it will auto correct if it spots an issue - you will need to run the git commit again after it has fixed the issue)
+* It automatically removes trailing whitespaces (again will need to run commit again after it detects and fixes the issue)
+* Detects aws credentials or private keys accidentally added to the repo
+* runs cloud formation linter and detects issues
+* runs checkov and checks for any issues.
+
+### Dependency Installation
+To use this locally you will first need to install the dependencies, this can be done in 2 ways:
+
+#### Method 1 - Python pip
+
+Run the following in a terminal:
+
+```
+sudo -H pip3 install checkov pre-commit cfn-lint
+```
+
+this should work across platforms
+
+#### Method 2 - Brew
+
+If you have brew installed please run the following:
+
+```
+brew install pre-commit ;\
+brew install cfn-lint ;\
+brew install checkov
+```
+
+### Post Installation Configuration
+once installed run:
+```
+pre-commit install
+```
+
+To update the various versions of the pre-commit plugins, this can be done by running:
+
+```
+pre-commit autoupdate && pre-commit install
+```
+
+This will install / configure the pre-commit git hooks,  if it detects an issue while committing it will produce an output like the following:
+
+```
+ git commit -a
+check json...........................................(no files to check)Skipped
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+detect aws credentials...................................................Passed
+detect private key.......................................................Passed
+AWS CloudFormation Linter................................................Failed
+- hook id: cfn-python-lint
+- exit code: 4
+
+W3011 Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/PublicHostedZone from deletion
+core/deploy/dns-zones/template.yaml:20:3
+
+Checkov..............................................(no files to check)Skipped
+- hook id: checkov
+```
+
+To remove the pre-commit hooks should there be an issue
+```
+pre-commit uninstall
+```
+
 ## Build
 
 Build with `./gradlew`
@@ -60,7 +131,7 @@ The command to run is:
 
 ### Deploy to shared dev account
 
-Note deploy.sh has a prefix override set to use the existing dl-dev pipeline parameters, the prefix will need changed 
+Note deploy.sh has a prefix override set to use the existing dl-dev pipeline parameters, the prefix will need changed
 to "none" and all parameters set in the parameter store.
 
 `gds aws di-ipv-cri-dev -- ./deploy.sh di-ipv-cri-dl-myusernameORticket`


### PR DESCRIPTION
### What changed

- Added pre-commit GHA workflow step
- Added pre-commit-config with `detect-secrets`
- Added secrets.baseline with `detect-secrets scan --slim > .secrets.baseline`

### Why did it change

- As per ticket requirements

### Issue tracking

- [IPS-484](https://govukverify.atlassian.net/browse/IPS-484)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks



[IPS-484]: https://govukverify.atlassian.net/browse/IPS-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ