### PR TITLE
LIME-1212 Disable cucumber report publishing

### DIFF
--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -143,7 +143,6 @@ jobs:
           coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
           coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}
           orchestratorStubUrl: ${{ secrets.ORCHESTRATOR_STUB_URL }}
-          CUCUMBER_PUBLISH_ENABLED: true
           BROWSER: chrome-headless
         run: |
           echo "🤞 now run integration tests..."

--- a/.github/workflows/smoke-test-build.yml
+++ b/.github/workflows/smoke-test-build.yml
@@ -48,7 +48,6 @@ jobs:
         env:
           BROWSER: chrome-headless
           ENVIRONMENT: ${{ secrets.TEST_ENVIRONMENT }}
-          CUCUMBER_PUBLISH_ENABLED: true
           coreStubUrl: ${{ secrets.CORE_STUB_URL }}
           coreStubUsername: ${{ secrets.CORE_STUB_USERNAME }}
           coreStubPassword: ${{ secrets.CORE_STUB_PASSWORD }}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/runners/TestRunner.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/runners/TestRunner.java
@@ -6,7 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        publish = true,
+        publish = false,
         plugin = "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm",
         features = "src/test/resources/features",
         glue = "gov/di_ipv_drivingpermit/step_definitions",

--- a/acceptance-tests/src/test/resources/cucumber.properties
+++ b/acceptance-tests/src/test/resources/cucumber.properties
@@ -1,0 +1,2 @@
+cucumber.publish.quiet=false
+cucumber.publish.enabled=false


### PR DESCRIPTION
## Proposed changes

### What changed

Disabled auto-reporting via the following 

Add cucumber.properties with the following contents

	- cucumber.publish.quiet=false to ensure reporting if re-enabled is visible
	- cucumber.publish.enabled=false to stop the reporting.

Removed env-var CUCUMBER_PUBLISH_ENABLED: true from git hub actions

Change publish to false in @CucumberOptions in the test runner.

### Why did it change

To disable sending reports to a third-party

### Issue tracking

- [LIME-1212](https://govukverify.atlassian.net/browse/LIME-1212)


[LIME-1212]: https://govukverify.atlassian.net/browse/LIME-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ