### PR TITLE
LIME-1201 - Including Opaque KID in JWT headers for VCs

### DIFF
--- a/.github/workflows/run-sonar-scan.yml
+++ b/.github/workflows/run-sonar-scan.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/
       - name: Run SonarCloud Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -58,17 +58,17 @@ jobs:
         with:
           name: unit-test-reports
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/
           retention-days: 5
       - name: Cache Unit Test Reports
         uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
-            */build/jacoco/
-            */build/reports/
-            */lambdas/**/build/reports/
-            */lib*/build/reports/
+            build/jacoco/
+            build/reports/
+            lambdas/**/build/reports/
+            lib*/build/reports/

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.0.2",
+		cri_common_lib_version             : "3.0.4",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.26.16",
@@ -93,7 +93,7 @@ sonar {
 		property "sonar.organization", "govuk-one-login"
 		property "sonar.host.url", "https://sonarcloud.io"
 		property "sonar.java.coveragePlugin", "jacoco"
-		property "sonar.coverage.jacoco.xmlReportPath", "${buildDir}/reports/jacoco/reports/reports.xml"
+		property "sonar.coverage.jacoco.xmlReportPath", layout.buildDirectory.file("reports/jacoco/reports/reports.xml")
 	}
 }
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -275,18 +275,23 @@ Mappings:
     dev:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "true"
     build:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     staging:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     integration:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
     production:
       VcExpiryRemoved: "true"
       VcContainsUniqueIdMapping: "true"
+      IncludeKidInVc: "false"
 
 Resources:
 
@@ -629,6 +634,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
           ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcExpiryRemoved ]
           ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
+          INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -653,7 +659,9 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/MaxJwtTtl"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialService.java
@@ -20,6 +20,9 @@ import uk.gov.di.ipv.cri.drivingpermit.library.service.ParameterStoreService;
 import uk.gov.di.ipv.cri.drivingpermit.library.service.ServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.library.service.parameterstore.ParameterPrefix;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -53,7 +56,7 @@ public class VerifiableCredentialService {
             String subject,
             DocumentCheckResultItem documentCheckResultItem,
             PersonIdentityDetailed personIdentityDetailed)
-            throws JOSEException {
+            throws JOSEException, MalformedURLException, NoSuchAlgorithmException {
         long jwtTtl = commonLibConfigurationService.getMaxJwtTtl();
 
         ChronoUnit jwtTtlUnit =
@@ -79,7 +82,20 @@ public class VerifiableCredentialService {
                         .verifiableCredentialEvidence(calculateEvidence(documentCheckResultItem))
                         .build();
 
-        return signedJwtFactory.createSignedJwt(claimsSet);
+        SignedJWT signedJwt = null;
+        if (Boolean.parseBoolean(System.getenv("INCLUDE_VC_KID"))) {
+            String issuer =
+                    removeIssuerPrefix(
+                            commonLibConfigurationService.getCommonParameterValue(
+                                    "verifiable-credential/issuer"));
+            String kmsSigningKeyId =
+                    commonLibConfigurationService.getCommonParameterValue(
+                            "verifiableCredentialKmsSigningKeyId");
+            signedJwt = signedJwtFactory.createSignedJwt(claimsSet, issuer, kmsSigningKeyId);
+        } else {
+            signedJwt = signedJwtFactory.createSignedJwt(claimsSet);
+        }
+        return signedJwt;
     }
 
     private Object[] convertAddresses(List<Address> addresses) {
@@ -125,5 +141,10 @@ public class VerifiableCredentialService {
                     EvidenceHelper.documentCheckResultItemToEvidence(documentCheckResultItem),
                     Map.class)
         };
+    }
+
+    private String removeIssuerPrefix(String issuerUrl) throws MalformedURLException {
+        URL url = new URL(issuerUrl);
+        return url.getAuthority() + url.getPath();
     }
 }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandlerTest.java
@@ -46,6 +46,8 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.net.MalformedURLException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.UUID;
 
@@ -92,7 +94,8 @@ class IssueCredentialHandlerTest {
     }
 
     @Test
-    void shouldReturn200OkWhenIssueCredentialRequestIsValid() throws JOSEException, SqsException {
+    void shouldReturn200OkWhenIssueCredentialRequestIsValid()
+            throws JOSEException, SqsException, MalformedURLException, NoSuchAlgorithmException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(
@@ -166,7 +169,8 @@ class IssueCredentialHandlerTest {
 
     @Test
     void shouldThrowJOSEExceptionWhenGenerateVerifiableCredentialIsMalformed()
-            throws JOSEException, SqsException, JsonProcessingException {
+            throws JOSEException, SqsException, JsonProcessingException, MalformedURLException,
+                    NoSuchAlgorithmException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         AccessToken accessToken = new BearerAccessToken();
         event.withHeaders(

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
@@ -142,6 +142,7 @@ class IssueCredentialHandlerTest {
 
         environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, true);
         environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
+        environmentVariables.set("INCLUDE_VC_KID", "false");
 
         mockServiceFactoryBehaviour();
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/utils/PreLambdaHandler.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/utils/PreLambdaHandler.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -100,16 +99,15 @@ class PreLambdaHandler implements HttpHandler {
         return pathParams;
     }
 
-    public static Map<String, String> getQueryStringParams(URI url)
-            throws UnsupportedEncodingException {
+    public static Map<String, String> getQueryStringParams(URI url) {
         Map<String, String> query_pairs = new HashMap<>();
         String query = url.getQuery();
         String[] pairs = query.split("&");
         for (String pair : pairs) {
             int idx = pair.indexOf("=");
             query_pairs.put(
-                    URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
-                    URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
         }
         return query_pairs;
     }
@@ -218,6 +216,11 @@ class PreLambdaHandler implements HttpHandler {
         TreeMap<String, Object> test = new TreeMap<>();
         test.put("typ", jwt.getHeader().getType().getType());
         test.put("alg", jwt.getHeader().getAlgorithm().getName());
+
+        String keyID = ((JWSHeader) jwt.getHeader()).getKeyID();
+        if (keyID != null) {
+            test.put("kid", keyID);
+        }
 
         Base64URL jwtHeader = Base64URL.encode(new ObjectMapper().writeValueAsString(test));
         String[] serialize = signedJWT.serialize().split("\\.");


### PR DESCRIPTION
### What changed

Updated verifiableCredentialService to use updated jwtSigning implementation and include kid in jwt headers