### PR TITLE
LIME-1114 SessionNotFoundExceptions added to handlers

### DIFF
--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
@@ -19,11 +19,7 @@ import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -130,10 +126,7 @@ class IssueCredentialHandlerTest {
 
     @au.com.dius.pact.provider.junitsupport.loader.PactBrokerConsumerVersionSelectors
     public static SelectorBuilder consumerVersionSelectors() {
-        return new SelectorBuilder()
-                .tag("DrivingLicenceVcProvider")
-                .branch("main", "IpvCoreBack")
-                .deployedOrReleased();
+        return new SelectorBuilder().branch("main", "IpvCoreBack").deployedOrReleased();
     }
 
     @BeforeEach


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

SessionNotFoundException added to both Driving Permit Handler and Issue Credential handler. Corresponding unit tests also created.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

To ensure scenarios where a user has no session id are identified promptly and the correct error is returned.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)

PR for equivalent changes in passport CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/169)
PR for equivalent changes in fraud CRI has been completed [here](https://github.com/govuk-one-login/ipv-cri-fraud-api/pull/326)



[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ