### PR TITLE
Updating nimbus jwt and oauth in line with other LIME CRIs

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -31,8 +31,8 @@ dependencies {
 		aws_embedded_metrics_version       : "1.0.6",
 
 		// CRI_LIB nimbus
-		nimbusds_oauth_version             : "11.2",
-		nimbusds_jwt_version               : "9.36",
+		nimbusds_oauth_version             : "11.19.1",
+		nimbusds_jwt_version               : "9.41.1",
 
 		// CRI_LIB powertools
 		aws_powertools_logging_version     : "1.12.0",

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ ext {
 		aws_lambda_events_version          : "3.11.6",
 
 		// Nimbus Oauth
-		nimbusds_oauth_version             : "11.10.1",
-		nimbusds_jwt_version               : "9.37.3",
+		nimbusds_oauth_version             : "11.19.1",
+		nimbusds_jwt_version               : "9.41.1",
 
 		// CRI_LIB powertools
 		aws_powertools_logging_version     : "${aws_powertools_version}",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Nimbus JWT and Oauth dependencies updated in line with Fraud CRI and Passport CRI following equivalent Dependabot PRs being created for those CRIs.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

No Jira ticket but related to [this Fraud Dependabot PR](https://github.com/govuk-one-login/ipv-cri-fraud-api/pull/328) and [this Passport Dependabot PR](https://github.com/govuk-one-login/ipv-cri-uk-passport-api/pull/171)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
