### PR TITLE
LIME-1114: Added new API Acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceAPIStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceAPIStepDefs.java
@@ -38,6 +38,15 @@ public class DrivingLicenceAPIStepDefs extends DrivingLicenceAPIPage {
         postRequestToDrivingLicenceEndpoint(dlJsonRequestBody);
     }
 
+    @When(
+            "Driving Licence user sends a POST request to Driving Licence endpoint with a invalid (.*) value using jsonRequest (.*)$")
+    public void DL_user_sends_a_post_request_to_driving_licence_end_point_with_invalid_session_id(
+            String invalidHeaderValue, String dlJsonRequestBody)
+            throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
+        postRequestToDrivingLicenceEndpointWithInvalidSessionId(
+                invalidHeaderValue, dlJsonRequestBody);
+    }
+
     @And("Driving Licence check response should contain Retry value as (.*)$")
     public void DL_check_response_should_contain_Retry_value(Boolean retry) {
         retryValueInDLCheckResponse(retry);
@@ -57,6 +66,13 @@ public class DrivingLicenceAPIStepDefs extends DrivingLicenceAPIPage {
     @Then("User requests Driving Licence CRI VC")
     public void user_requests_DL_vc() throws IOException, InterruptedException, ParseException {
         postRequestToDrivingLicenceVCEndpoint();
+    }
+
+    @Then(
+            "User requests Driving Licence CRI VC from the Credential Issuer Endpoint with a invalid Bearer Token value")
+    public void user_requests_DL_vc_with_invalid_headers()
+            throws IOException, InterruptedException {
+        postRequestToDrivingLicenceVCEndpointWithInvalidAuthCode();
     }
 
     @And("Driving Licence VC should contain validityScore (.*) and strengthScore (.*)$")

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
@@ -68,3 +68,26 @@ Feature: DVA CRI API
     Then User requests Driving Licence CRI VC
     And Driving Licence VC should contain ci D02, validityScore 0 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in failed checkDetails
+
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario Outline: DVA Driving Licence Un-Happy path with invalid sessionId on Driving Licence Endpoint
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint with a invalid <invalidHeaderValue> value using jsonRequest DVAInvalidJsonPayload
+    Examples:
+      |invalidHeaderValue              |
+      | invalidSessionId               |
+      | malformedSessionId             |
+      | missingSessionId               |
+      | noSessionHeader                |
+
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario: DVA Driving Licence Un-Happy path with invalid authCode on Credential Issuer Endpoint
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVAValidKennethJsonPayload
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC from the Credential Issuer Endpoint with a invalid Bearer Token value

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
@@ -91,3 +91,26 @@ Feature: DrivingLicence CRI API
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE500456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE502456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE504456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
+
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario Outline: DVLA Driving Licence Un-Happy path with invalid sessionId on Driving Licence Endpoint
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint with a invalid <invalidHeaderValue> value using jsonRequest DVAInvalidJsonPayload
+    Examples:
+      |invalidHeaderValue              |
+      | mismatchSessionId               |
+      | malformedSessionId             |
+      | missingSessionId               |
+      | noSessionHeader                |
+
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario: DVLA Driving Licence Un-Happy path with invalid authCode on Credential Issuer Endpoint
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using jsonRequest DVLAValidKennethJsonPayload
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC from the Credential Issuer Endpoint with a invalid Bearer Token value


### PR DESCRIPTION
to check that when a invalid sessionid is sent to the driving licence endpoint, or authcode is sent in credential issuer endpoint

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1114] PR Title` -->

## Proposed changes

### What changed
Added new acceptance-tests to DVA and DVA Api tests
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To add coverage to the changes made in LIME-1114 around incoming session_id header is not null
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1114](https://govukverify.atlassian.net/browse/LIME-1114)

### Other considerations
All New tests passed locally:
![image](https://github.com/user-attachments/assets/3f927340-17c3-4493-b8c0-cf9ead010daa)

All existing tests passing locally: 
![image](https://github.com/user-attachments/assets/a7969a99-73aa-4535-a9f5-af532a8385b9)

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1114]: https://govukverify.atlassian.net/browse/LIME-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ