### PR TITLE
BAU-AC-TestFix - Test if waiting for Visit Credential Issuers page to load makes ac tests less flaky

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -425,6 +425,7 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     public void navigateToDrivingLicenceCRIOnTestEnv() {
         visitCredentialIssuers.click();
+        assertPageTitle(IPV_CORE_STUB, true);
         String dlCRITestEnvironment = configurationService.getDlCRITestEnvironment();
         LOGGER.info("dlCRITestEnvironment = " + dlCRITestEnvironment);
         if (dlCRITestEnvironment.equalsIgnoreCase("dev")


### PR DESCRIPTION
## Proposed changes

### What changed

Add an assertPageTitle after clicking visitCredentialIssuers to wait for the page to load.

### Why did it change

Test logs appear to show the code checking for elements before the page has loaded fully

