### PR TITLE
LIME-1208 Add dev perf test script and correctly clean up after each ac test

### DIFF
--- a/acceptance-tests/run-dev-perf-test.sh
+++ b/acceptance-tests/run-dev-perf-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This uses the same config as the run-local-test.sh
+# Configure it for the pipeline dev environment
+CONF_FILE=test-args.conf
+if [ -f "$CONF_FILE" ]; then
+  export $(grep -v '^#' $CONF_FILE | xargs)
+fi
+
+export BROWSER
+export ENVIRONMENT
+
+if [ "$ENVIRONMENT" != "dev" ]; then
+  echo -e "\033[0;31mWarning Executing Perf test against $ENVIRONMENT\033[0m"
+fi
+
+echo -e "\033[0;31mWarning this is a performance test please close any programs and save work you do not want to loose.\033[0m"
+echo -e "\033[0;31mPlease ensure your computer has 16gb of currently FREE memory\033[0m"
+echo -e "\033[0;31mPlease ensure your computer not being used for this test to valid\033[0m"
+read -p "Press <enter> to continue" I_UNDER_STAND_I_MAY_LOOSE_WORK
+echo -e "\033[1;33mTest Running (Expected run-time 20mins~) \033[0m"
+
+export coreStubUrl=$CORE_STUB_URL
+export coreStubUsername=$CORE_STUB_USERNAME
+export coreStubPassword=$CORE_STUB_PASSWORD
+export orchestratorStubUrl=$ORCHESTRATOR_URL
+export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
+export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
+
+###### Run tests
+seq 16 | parallel --progress -j8 -n0 ./gradlew cucumber -P tags=${TAG}
+
+echo -e "\033[1;33mTest Complete\033[0m"

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
@@ -1,6 +1,7 @@
 package gov.di_ipv_drivingpermit.step_definitions;
 
 import gov.di_ipv_drivingpermit.pages.UniversalSteps;
+import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.changeLanguageTo;
@@ -15,5 +16,11 @@ public class UniversalStepDefs extends UniversalSteps {
     @And("^I add a cookie to change the language to (.*)$")
     public void iAddACookieToChangeTheLanguageToWelsh(String language) {
         changeLanguageTo(language);
+    }
+
+    @After
+    public void cleanUp() {
+        System.out.println("CleanUp after test");
+        driverClose();
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/Driver.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/Driver.java
@@ -92,19 +92,14 @@ public class Driver {
             }
         }
 
-        try {
-            // Avoid increasing this too much as Driver.get() is called many times,
-            // A correct fix is to check the document state where needed.
-            Thread.sleep(50);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-
         return driverPool.get();
     }
 
     public static void closeDriver() {
-        driverPool.get().quit();
-        driverPool.remove();
+        if (driverPool.get() != null) {
+            driverPool.get().close();
+            driverPool.get().quit();
+            driverPool.remove();
+        }
     }
 }

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
@@ -80,17 +80,32 @@ Feature: DrivingLicence CRI API
     Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
     And Driving Licence user sends a POST request to session endpoint
     And Driving Licence user gets a session-id
-    When Driving Licence user sends a editable POST request to Driving Licence endpoint using jsonRequest <PassportJsonPayload> with edited fields <jsonEdits>
+    When Driving Licence user sends a editable POST request to Driving Licence endpoint using jsonRequest <JsonPayload> with edited fields <jsonEdits>
     Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
     Examples:
-      |PassportJsonPayload         | jsonEdits                                                                  | cri_internal_error_code | cri_internal_error_message                                  |
+      |JsonPayload                 | jsonEdits                                                                  | cri_internal_error_code | cri_internal_error_message                                  |
       |DVLAValidKennethJsonPayload | {"surname": "Unauthorized", "drivingLicenceNumber" : "UNAUT123456AB1AB"}   | 1316                    | error dvla expired token recovery failed                    |
       |DVLAValidKennethJsonPayload | {"surname": "Forbidden", "drivingLicenceNumber" : "FORBI123456AB1AB"}      | 1314                    | error match endpoint returned unexpected http status code   |
-      |DVLAValidKennethJsonPayload | {"surname": "CannotBeFound", "drivingLicenceNumber" : "CANNO123456AB1AB"}  | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "TooManyRequest", "drivingLicenceNumber" : "TOOMA123456AB1AB"} | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE500456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE502456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
       |DVLAValidKennethJsonPayload | {"surname": "ServerError", "drivingLicenceNumber" : "SERVE504456AB1AB"}    | 1314                    | error match endpoint returned unexpected http status code   |
+
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario Outline: Test Driving Licence API handles 404 on the match endpoint
+    Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a editable POST request to Driving Licence endpoint using jsonRequest <JsonPayload> with edited fields <jsonEdits>
+    Then Driving Licence check response should contain Retry value as true
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC
+    And Driving Licence VC should contain ci D02, validityScore 0 and strengthScore 3
+    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in failed checkDetails
+    Examples:
+      |JsonPayload                 | jsonEdits                                                                 |
+      |DVLAValidKennethJsonPayload | {"surname": "CannotBeFound", "drivingLicenceNumber" : "CANNO123456AB1AB"} |
 
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario Outline: DVLA Driving Licence Un-Happy path with invalid sessionId on Driving Licence Endpoint


### PR DESCRIPTION
## Proposed changes

### What changed

Add dev perf test script.

Correctly clean up after each ac test.

	- Move "400 CannotBeFound" scenario into a separate test now that it is being handled correctly by the stub
	- Note this commit removes the sleep in driver.get()


### Why did it change

To allow a faster build and test iteration with-out involving a full formal perf test.

Ac test where leaving the driver open, leaving lots of browsers open after the test.
This change closes the driver after each test using in built cucumber support.

The CannotBeFound scenario is now being retuned as expected from the stub and is being handled correctly in the happy path by the CRI.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1208](https://govukverify.atlassian.net/browse/LIME-1208)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1208]: https://govukverify.atlassian.net/browse/LIME-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ