### PR TITLE
LIME-1312 Update to CRI lib 3.1.3

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -17,27 +17,29 @@ configurations {
 	}
 }
 
+
 dependencies {
+	var aws_powertools_version = "1.18.0"
+	var java_cucumber_version = "7.20.1"
 	var dependencyVersions = [
 		// ---------------------------------------------------------
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fix.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "1.6.2",
+		cri_common_lib_version             : "3.1.3",
 
 		// CRI_LIB aws
 		aws_sdk_version                    : "2.28.8",
 		aws_lambda_events_version          : "3.11.0",
-		aws_embedded_metrics_version       : "1.0.6",
 
 		// CRI_LIB nimbus
 		nimbusds_oauth_version             : "11.19.1",
 		nimbusds_jwt_version               : "9.41.1",
 
 		// CRI_LIB powertools
-		aws_powertools_logging_version     : "1.12.0",
-		aws_powertools_metrics_version     : "1.12.0",
-		aws_powertools_parameters_version  : "1.12.0",
+		aws_powertools_logging_version     : "${aws_powertools_version}",
+		aws_powertools_metrics_version     : "${aws_powertools_version}",
+		aws_powertools_parameters_version  : "${aws_powertools_version}",
 
 		// ---------------------------------------------------------
 		// AC Test Dependencies (DL CRI)
@@ -57,17 +59,17 @@ dependencies {
 
 		// acceptance tests Implementation
 		// Update these together
-		cucumber_version                   : "7.18.1",
-		selenium_version                   : "4.24.0",
-		axe_core_selenium_version          : "4.6.0",
-		webdrivermanager_version           : "5.6.4",
+		cucumber_version                   : "${java_cucumber_version}",
+		selenium_version                   : "4.25.0",
+		axe_core_selenium_version          : "4.10.0",
+		webdrivermanager_version           : "5.9.2",
 
 		// acceptance tests testImplementation
-		rest_assured_version               : "5.3.0",
-		cucumber_junit_version             : "7.13.0"
+		rest_assured_version               : "5.5.0",
+		cucumber_junit_version             : "${java_cucumber_version}"
 	]
 
-	implementation "software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
 			"com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
 			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 		// cri_common_lib dependencies should match the ipv-cri-lib version
 		// Workaround until dependency resolution is fixed.
 		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.1.1",
+		cri_common_lib_version             : "3.1.3",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.28.8",

--- a/lambdas/certexpiryreminder/build.gradle
+++ b/lambdas/certexpiryreminder/build.gradle
@@ -13,10 +13,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"), project(":lib-dva"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"), project(":lib-dva"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}",

--- a/lambdas/drivingpermitcheck/build.gradle
+++ b/lambdas/drivingpermitcheck/build.gradle
@@ -13,10 +13,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"), project(":lib-dva"), project(":lib-dvla"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"), project(":lib-dva"), project(":lib-dvla"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}",

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.drivingpermit.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.impl.client.CloseableHttpClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.configuration.DrivingPermitConfigurationService;
@@ -129,6 +130,8 @@ public class ThirdPartyAPIServiceFactory {
                 drivingPermitConfigurationService.getDvlaConfiguration();
         ObjectMapper objectMapper = serviceFactory.getObjectMapper();
         EventProbe eventProbe = serviceFactory.getEventProbe();
+        DynamoDbEnhancedClient dynamoDbEnhancedClient =
+                serviceFactory.getClientProviderFactory().getDynamoDbEnhancedClient();
         ApacheHTTPClientFactoryService apacheHTTPClientFactoryService =
                 serviceFactory.getApacheHTTPClientFactoryService();
 
@@ -140,7 +143,12 @@ public class ThirdPartyAPIServiceFactory {
                         dvlaCloseableHttpClientFactory.getClient(), eventProbe, MAX_HTTP_RETRIES);
 
         DvlaEndpointFactory dvlaEndpointFactory =
-                new DvlaEndpointFactory(dvlaConfiguration, objectMapper, eventProbe, httpRetryer);
+                new DvlaEndpointFactory(
+                        dvlaConfiguration,
+                        objectMapper,
+                        eventProbe,
+                        httpRetryer,
+                        dynamoDbEnhancedClient);
 
         return new DvlaThirdPartyDocumentGateway(dvlaEndpointFactory);
     }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactoryTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.services.acm.model.ExportCertificateResponse;
 import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
@@ -59,6 +60,7 @@ class ThirdPartyAPIServiceFactoryTest {
     @Mock ObjectMapper mockObjectMapper;
     @Mock EventProbe mockEventProbe;
     @Mock AcmCertificateService acmCertificateService;
+    @Mock DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
 
     private ThirdPartyAPIServiceFactory thirdPartyAPIServiceFactory;
 
@@ -87,6 +89,8 @@ class ThirdPartyAPIServiceFactoryTest {
 
         // DVLA
         when(mockServiceFactory.getEventProbe()).thenReturn(mockEventProbe);
+        when(clientProviderFactory.getDynamoDbEnhancedClient())
+                .thenReturn(mockDynamoDbEnhancedClient);
 
         when(mockDrivingPermitConfigurationService.getDvlaConfiguration())
                 .thenReturn(mockDvlaConfiguration);

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -13,10 +13,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}",

--- a/lambdas/passwordRenewal/build.gradle
+++ b/lambdas/passwordRenewal/build.gradle
@@ -12,10 +12,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"), project(":lib-dvla"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"), project(":lib-dvla"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
 			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",

--- a/lambdas/passwordRenewal/src/main/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandler.java
+++ b/lambdas/passwordRenewal/src/main/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandler.java
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.util.ClientProviderFactory;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.event.endpoints.ChangePasswordService;
@@ -84,7 +83,7 @@ public class PasswordRenewalHandler implements RequestHandler<SecretsManagerRota
         tokenRequestService =
                 new TokenRequestService(
                         dvlaConfiguration,
-                        DataStore.getClient(),
+                        clientProviderFactory.getDynamoDbEnhancedClient(),
                         httpRetryer,
                         defaultRequestConfig,
                         objectMapper,

--- a/lib-dva/build.gradle
+++ b/lib-dva/build.gradle
@@ -13,10 +13,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",

--- a/lib-dvla/build.gradle
+++ b/lib-dvla/build.gradle
@@ -13,10 +13,12 @@ configurations.all {
 	// https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/
 	exclude group:"software.amazon.awssdk", module: "apache-client"
 	exclude group:"software.amazon.awssdk", module: "netty-nio-client"
+	exclude group:"software.amazon.awssdk", module: "url-connection-client"
 }
 
 dependencies {
-	implementation project(":lib"),
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			project(":lib"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",

--- a/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/DvlaEndpointFactory.java
+++ b/lib-dvla/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/dvla/service/DvlaEndpointFactory.java
@@ -3,8 +3,8 @@ package uk.gov.di.ipv.cri.drivingpermit.library.dvla.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.apache.http.client.config.RequestConfig;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.library.config.HttpRequestConfig;
 import uk.gov.di.ipv.cri.drivingpermit.library.dvla.configuration.DvlaConfiguration;
@@ -23,7 +23,8 @@ public class DvlaEndpointFactory {
             DvlaConfiguration dvlaConfiguration,
             ObjectMapper objectMapper,
             EventProbe eventProbe,
-            HttpRetryer httpRetryer) {
+            HttpRetryer httpRetryer,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
 
         // Same on all endpoints
         RequestConfig defaultRequestConfig = new HttpRequestConfig().getDefaultRequestConfig();
@@ -31,7 +32,7 @@ public class DvlaEndpointFactory {
         tokenRequestService =
                 new TokenRequestService(
                         dvlaConfiguration,
-                        DataStore.getClient(),
+                        dynamoDbEnhancedClient,
                         httpRetryer,
                         defaultRequestConfig,
                         objectMapper,

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,7 +11,8 @@ plugins {
 
 dependencies {
 
-	implementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
+	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
 			"software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_version}",

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/service/DocumentCheckResultStorageService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/service/DocumentCheckResultStorageService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.drivingpermit.library.service;
 
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.drivingpermit.library.persistence.item.DocumentCheckResultItem;
 
@@ -13,13 +14,14 @@ public class DocumentCheckResultStorageService {
         this.dataStore = dataStore;
     }
 
-    public DocumentCheckResultStorageService(String documentCheckTableName) {
+    public DocumentCheckResultStorageService(
+            String documentCheckTableName, DynamoDbEnhancedClient dynamoDbEnhancedClient) {
 
         this.dataStore =
                 new DataStore<>(
                         documentCheckTableName,
                         DocumentCheckResultItem.class,
-                        DataStore.getClient());
+                        dynamoDbEnhancedClient);
     }
 
     public DocumentCheckResultItem getDocumentCheckResult(UUID sessionId) {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/service/ServiceFactory.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/service/ServiceFactory.java
@@ -74,7 +74,8 @@ public class ServiceFactory {
                         ParameterStoreParameters.DOCUMENT_CHECK_RESULT_TABLE_NAME);
 
         this.documentCheckResultStorageService =
-                new DocumentCheckResultStorageService(documentCheckTableName);
+                new DocumentCheckResultStorageService(
+                        documentCheckTableName, clientProviderFactory.getDynamoDbEnhancedClient());
 
         this.personIdentityService =
                 new PersonIdentityService(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

	CRI
	- Correct floating aws sdk client components versions causing runtime failures (java.lang.IncompatibleClassChangeError)
	- - clients ssm, secretsmanager, appconfigdata
	- exclude un-needed url-connection-client from being packaged.
	- Correct using a dedicated DynamoDbEnhancedClient for all Datastores instead of a shared DynamoDbEnhancedClient.

	Ac Tests
	- Update cri_common_lib_version to 3.1.3 in ac tests
	- Link aws_powertools_logging_version, aws_powertools_metrics_version and aws_powertools_parameters_version to aws_powertools_version in ac test
	- Remove aws_embedded_metrics_version from ac test
	- Link cucumber_junit_version and cucumber_version to java_cucumber_version in ac tests.
	- Update selenium_version, axe_core_selenium_version and webdrivermanager_version

### Why did it change

To correct a version mismatch at run-time when using AWS SDK 2.28.x and 2.21.x clients pulled in as transitive dependancies of power-tools.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1312](https://govukverify.atlassian.net/browse/LIME-1312)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1312]: https://govukverify.atlassian.net/browse/LIME-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ