### PR TITLE
LIME-1365 - Update Auth Source Test Tags to disable running in Staging environment

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -1,6 +1,7 @@
 Feature: DVA Auth Source Driving Licence Test
 
-  @build @staging @integration @smoke @stub @uat
+#  @staging @integration
+  @build @smoke @stub @uat
   Scenario Outline: DVA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -1,6 +1,7 @@
 Feature: DVLA Auth Source Driving Licence Test
 
-  @build @staging @integration @smoke @stub @uat
+#  @staging @integration
+  @build @smoke @stub @uat
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value check_details in the Input context value as a string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Currently the feature-flag for Auth Source is disable in Staging

### Why did it change

Tests for Auth Source have been updated to remove the Tags that allow running in Staging

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1365](https://govukverify.atlassian.net/browse/LIME-1365)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1365]: https://govukverify.atlassian.net/browse/LIME-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ