### PR TITLE
LIME-1366 - Update Auth Source Test Tags to disable running in Staging environment - UAT Tag

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -1,7 +1,7 @@
 Feature: DVA Auth Source Driving Licence Test
 
-#  @staging @integration
-  @build @smoke @stub @uat
+#  @staging @integration @uat
+  @build @smoke @stub
   Scenario Outline: DVA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -1,7 +1,7 @@
 Feature: DVLA Auth Source Driving Licence Test
 
-#  @staging @integration
-  @build @smoke @stub @uat
+#  @staging @integration @uat
+  @build @smoke @stub
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value check_details in the Input context value as a string


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1366] PR Title` -->

## Proposed changes

### What changed

commented out the @uat test tag on the auth source post-merge tests


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1366](https://govukverify.atlassian.net/browse/LIME-1366)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1366]: https://govukverify.atlassian.net/browse/LIME-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1366]: https://govukverify.atlassian.net/browse/LIME-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ