### PR TITLE
LIME-1367: DL Auth Source - Update API and UI Tests

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -240,7 +240,10 @@ public class DrivingLicencePageObject extends UniversalSteps {
     public WebElement Continue;
 
     @FindBy(xpath = "//*[@id=\"confirmDetails\"]")
-    public WebElement radioButton;
+    public WebElement correctDetailsRadioButton;
+
+    @FindBy(xpath = "//*[@id=\"confirmDetails-detailsNotConfirmed\"]")
+    public WebElement incorrectDetailsRadioButton;
 
     @FindBy(id = "header")
     public WebElement pageHeader;
@@ -253,6 +256,9 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     @FindBy(className = "govuk-details__text")
     public WebElement whyWePara;
+
+    @FindBy(id = "consentDVACheckbox")
+    public WebElement consentDVACheckbox;
 
     // Error summary items
 
@@ -1090,6 +1096,10 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     public void assertInvalidMiddleNameOnField(String expectedText) {
         assertEquals(expectedText, InvalidMiddleNamesFieldError.getText().trim().replace("\n", ""));
+    }
+
+    public void assertNoConsentGivenInErrorSummary(String expectedText) {
+        assertEquals(expectedText, DVLAConsentCheckboxError.getText());
     }
 
     public void ciInVC(String ci) throws IOException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -17,9 +17,19 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
         Continue.click();
     }
 
-    @Then("User clicks selects the Radio Button")
+    @When("User click the consent checkbox")
+    public void user_clicks_on_consent_box() {
+        consentDVACheckbox.click();
+    }
+
+    @Then("User clicks selects the Yes Radio Button")
     public void user_clicks_on_radio_button_yes() {
-        radioButton.click();
+        correctDetailsRadioButton.click();
+    }
+
+    @Then("User clicks selects the No Radio Button")
+    public void user_clicks_on_radio_button_no() {
+        incorrectDetailsRadioButton.click();
     }
 
     @Then("Proper error message for Could not find your details is displayed")
@@ -60,6 +70,11 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     @Then("^I see the licence number error in the summary as (.*)$")
     public void shortDrivingLicenceNumberErrorMessageIsDisplayed(String expectedText) {
         assertInvalidLicenceNumberInErrorSummary(expectedText);
+    }
+
+    @Then("^I see the give your consent error in the summary as (.*)$")
+    public void noConsentGivenErrorMessageIsDisplayed(String expectedText) {
+        assertNoConsentGivenInErrorSummary(expectedText);
     }
 
     @Then("^I can see the licence number error in the field as (.*)$")

--- a/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidBillyJsonPayload.json
+++ b/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidBillyJsonPayload.json
@@ -1,0 +1,34 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "BILLY"
+        },
+        {
+          "type": "FamilyName",
+          "value": "BATSON"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1981-07-26"
+    }
+  ],
+  "drivingPermit": [
+    {
+      "personalNumber": "55667788",
+      "expiryDate": "2042-10-01",
+      "issueDate": "2018-04-19",
+      "issuedBy": "DVA",
+      "fullAddress": "70 OLD BAKERS COURT BELFAST NW4 5RG"
+    }
+  ]
+}

--- a/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidKennethJsonPayload.json
+++ b/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidKennethJsonPayload.json
@@ -1,0 +1,34 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ],
+  "drivingPermit": [
+    {
+      "personalNumber": "12345678",
+      "expiryDate": "2042-10-01",
+      "issueDate": "2018-04-19",
+      "issuedBy": "DVA",
+      "fullAddress": ""
+    }
+  ]
+}

--- a/acceptance-tests/src/test/resources/Data/DVLAAuthSourceInvalidKennethJsonPayloadNoAddress.json
+++ b/acceptance-tests/src/test/resources/Data/DVLAAuthSourceInvalidKennethJsonPayloadNoAddress.json
@@ -1,0 +1,35 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld"
+  ],
+  "name": [
+    {
+      "nameParts": [
+        {
+          "type": "GivenName",
+          "value": "KENNETH"
+        },
+        {
+          "type": "FamilyName",
+          "value": "DECERQUEIRA"
+        }
+      ]
+    }
+  ],
+  "birthDate": [
+    {
+      "value": "1965-07-08"
+    }
+  ],
+  "drivingPermit": [
+    {
+      "personalNumber": "DECER607085K99AE",
+      "expiryDate": "2025-04-27",
+      "issueDate": "2023-08-22",
+      "issueNumber": "16",
+      "issuedBy": "DVLA",
+      "fullAddress": ""
+    }
+  ]
+}

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
@@ -19,6 +19,19 @@ Feature: DVA CRI API
       | check_details | 12345678       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH BA2 5AA          | DVAAuthValidKennethJsonPayload |
       | check_details | 55667788       | 2042-10-01 | 2018-04-19 | DVA      | 70 OLD BAKERS COURT BELFAST NW3 5RG | DVAAuthValidBillyJsonPayload   |
 
+#  @drivingLicenceCRI_API @pre-merge @dev
+#  Scenario Outline: DVA Driving Licence - Auth Source Retry Journey Happy Path
+#    Given DVA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
+#    And Driving Licence user sends a POST request to session endpoint
+#    And Driving Licence user gets a session-id
+#    And Driving Licence user sends a GET request to the personInfo endpoint
+#    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
+#    Then Driving Licence check response should contain Retry value as false
+#    Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
+#    Examples:
+#      | context       | personalNumber | expiryDate | issueDate  | issuedBy | fullAddress                | JSONPayloadRequest    | cri_internal_error_code | cri_internal_error_message    |
+#      | check_details | 12345678       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH BA2 5AA | DVAInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario: DVA Driving Licence Happy path
     Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -1,6 +1,6 @@
 Feature: DVA Auth Source Driving Licence Test
 
-#  @staging @integration @uat
+  #  @staging @integration @uat
   @build @smoke @stub
   Scenario Outline: DVA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
@@ -8,8 +8,11 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
-    And User clicks selects the Radio Button
+    And User clicks selects the Yes Radio Button
     When User clicks on continue
+#    And I check the page title is We need to check your driving licence details with the DVA – Prove your identity – GOV.UK
+#    And User click the consent checkbox
+#    When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number <personalNumber> same as given Driving Licence
@@ -19,3 +22,108 @@ Feature: DVA Auth Source Driving Licence Test
       | contextValue  | DVADrivingLicenceAuthSourceSubject   | personalNumber |
       | check_details | DVAAuthSourceValidBillyJsonPayload   | 55667788       |
       | check_details | DVAAuthSourceValidKennethJsonPayload | 12345678       |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVA Auth Source - Validation Test - Invalid Context Values
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Invalid Context field value and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject |
+      | check_detail  | DVAAuthSourceValidBillyJsonPayload |
+      | invalid_value | DVAAuthSourceValidBillyJsonPayload |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVA Auth Source - Validation Test - Missing context field directs to default DVA journey
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    Then I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I should see DVA as an option
+    And I click on DVA radio button and Continue
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I see a form requesting DVA LicenceNumber
+    Given User enters DVA data as a <DVADrivingLicenceSubject>
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
+    And JSON response should contain personal number <personalNumber> same as given Driving Licence
+    And JSON response should contain JTI field
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue | DVADrivingLicenceAuthSourceSubject | personalNumber | DVADrivingLicenceSubject           |
+      |              | DVAAuthSourceValidBillyJsonPayload | 55667788       | DVADrivingLicenceSubjectHappyBilly |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVA Auth Source - Raw JSON Object Validation Tests - Missing Address field in Claimset
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Internal server error and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject     |
+      | check_details | DVAAuthSourceInvalidKennethJsonPayload |
+
+  #  @staging @integration @uat
+  #  This test will require updating following fix in LIME-1328
+  @build @smoke @stub
+  Scenario Outline: DVA Auth Source - Negative Scenario - Postcode does not match the DVA Stub expected value
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the Yes Radio Button
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Authorization permission denied and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject   |
+      | check_details | DVAAuthSourceInvalidBillyJsonPayload |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVA Auth Source - Happy path - User selects No on the check your details are correct page
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the No Radio Button
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Authorization permission denied and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject   |
+      | check_details | DVAAuthSourceValidBillyJsonPayload   |
+      | check_details | DVAAuthSourceValidKennethJsonPayload |
+
+#  #  @staging @integration @uat
+#  @build @smoke @stub
+#  Scenario Outline: DVA Auth Source - Error Validation Text - Fail to provide consent
+#    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+#    And I enter the context value <contextValue> in the Input context value as a string
+#    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+#    And I add a cookie to change the language to English
+#    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+#    And User clicks selects the Yes Radio Button
+#    When User clicks on continue
+##    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+##    When User clicks on continue
+##    And I see the give your consent error in the summary as You must give your consent to continue
+#    And The test is complete and I close the driver
+#    Examples:
+#      | contextValue  | DVADrivingLicenceAuthSourceSubject   |
+#      | check_details | DVAAuthSourceValidBillyJsonPayload   |
+#      | check_details | DVAAuthSourceValidKennethJsonPayload |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
@@ -19,6 +19,26 @@ Feature: DrivingLicence CRI API
       | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH TB2 5AA | DVLAValidKennethJsonPayload |
       | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH BA2 5AA | DVLAValidKennethJsonPayload |
 
+#  @drivingLicenceCRI_API @pre-merge @dev
+#  Scenario Outline: DVLA Driving Licence - Auth Source Retry Journey Happy Path
+#    Given DVLA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issueNumber>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
+#    And Driving Licence user sends a POST request to session endpoint
+#    And Driving Licence user gets a session-id
+#    And Driving Licence user sends a GET request to the personInfo endpoint
+#    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
+#    Then Driving Licence check response should contain Retry value as true
+#    And Driving Licence user gets authorisation code
+#    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+#    Then User requests Driving Licence CRI VC
+#    And Driving Licence VC should contain validityScore 2 and strengthScore 3
+#    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+#    And Driving Licence VC should contain JTI field
+##    Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
+#    Examples:
+#      | context       | personalNumber   | expiryDate | issueDate  | issueNumber | issuedBy | fullAddress                | JSONPayloadRequest     | cri_internal_error_code | cri_internal_error_message    |
+#      | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH TB2 5AA | DVLAInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+
+
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario: DVLA Driving Licence Happy path
     Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -1,20 +1,108 @@
 Feature: DVLA Auth Source Driving Licence Test
 
-#  @staging @integration @uat
+  #  @staging @integration @uat
   @build @smoke @stub
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
-    And I enter the context value check_details in the Input context value as a string
-    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
-    And User clicks selects the Radio Button
+    And User clicks selects the Yes Radio Button
     When User clicks on continue
+#    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+#    And User click the consent checkbox
+#    When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number DECER607085K99AE same as given Driving Licence
     And JSON response should contain JTI field
     And The test is complete and I close the driver
     Examples:
-      | DVADrivingLicenceAuthSourceSubject    |
-      | DVLAAuthSourceValidKennethJsonPayload |
+      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
+      | check_details | DVLAAuthSourceValidKennethJsonPayload |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVLA Auth Source - Validation Test - Invalid Context Values
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Invalid Context field value and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
+      | check_detail  | DVLAAuthSourceValidKennethJsonPayload |
+      | invalid_value | DVLAAuthSourceValidKennethJsonPayload |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVLA Auth Source - Validation Test - Missing context field directs to default DVLA journey
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    Then I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I should see DVLA as an option
+    And I click on DVLA radio button and Continue
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I see a form requesting DVLA LicenceNumber
+    Given User enters DVLA data as a <DVLADrivingLicenceSubject>
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
+    And JSON response should contain personal number <personalNumber> same as given Driving Licence
+    And JSON response should contain JTI field
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue | DVLADrivingLicenceAuthSourceSubject   | personalNumber   | DVLADrivingLicenceSubject         |
+      |              | DVLAAuthSourceValidKennethJsonPayload | DECER607085K99AE | DrivingLicenceSubjectHappyKenneth |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVLA Auth Source - Raw JSON Object Validation Tests - Missing Address field in Claimset
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Internal server error and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVLADrivingLicenceAuthSourceSubject              |
+      | check_details | DVLAAuthSourceInvalidKennethJsonPayloadNoAddress |
+
+  #  @staging @integration @uat
+  @build @smoke @stub
+  Scenario Outline: DVLA Auth Source - Happy path
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the No Radio Button
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
+    And JSON response should contain error description Authorization permission denied and status code as 302
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
+      | check_details | DVLAAuthSourceValidKennethJsonPayload |
+
+#  #  @staging @integration @uat
+#  @build @smoke @stub
+#  Scenario Outline: DVLA Auth Source - Error Validation Text - Fail to provide consent
+#    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+#    And I enter the context value <contextValue> in the Input context value as a string
+#    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+#    And I add a cookie to change the language to English
+#    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+#    And User clicks selects the Yes Radio Button
+#    When User clicks on continue
+##    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+##    When User clicks on continue
+##    And I see the give your consent error in the summary as You must give your consent to continue
+#    And The test is complete and I close the driver
+#    Examples:
+#      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
+#      | check_details | DVLAAuthSourceValidKennethJsonPayload |


### PR DESCRIPTION
LIME-1367: 

New Tests added to cover extra happy path and unhappy path scenarios
Across both API Pre-merge tests
And UI Post-merge tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1367](https://govukverify.atlassian.net/browse/LIME-1367)

### Other considerations

API Pre-merge tests Passed Locally:
![image](https://github.com/user-attachments/assets/46d64f71-a11d-40fe-b6c7-265a6606fd04)

UI Post-merge tests passed locally:
![image](https://github.com/user-attachments/assets/f3ad686b-7b39-4ef1-9eb4-3d5a8e049ccc)


[LIME-1367]: https://govukverify.atlassian.net/browse/LIME-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ