### PR TITLE
LIME-1328/test LIME-1367: auth source tests amended

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -351,6 +351,9 @@ public class DrivingLicencePageObject extends UniversalSteps {
     @FindBy(id = "consentCheckbox-error")
     public WebElement DVLAConsentCheckboxError;
 
+    @FindBy(id = "consentDVACheckbox-error")
+    public WebElement dvaConsentCheckboxError;
+
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/div/form/h2")
     public WebElement DVLAConsentSection;
 
@@ -1099,7 +1102,13 @@ public class DrivingLicencePageObject extends UniversalSteps {
     }
 
     public void assertNoConsentGivenInErrorSummary(String expectedText) {
-        assertEquals(expectedText, DVLAConsentCheckboxError.getText());
+        String formattedErrorText = DVLAConsentCheckboxError.getText().replaceAll("\\s+", " ");
+        assertEquals(expectedText, formattedErrorText);
+    }
+
+    public void assertNoConsentGivenInDVAErrorSummary(String expectedText) {
+        String formattedErrorText = dvaConsentCheckboxError.getText().replaceAll("\\s+", " ");
+        assertEquals(expectedText, formattedErrorText);
     }
 
     public void ciInVC(String ci) throws IOException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -17,9 +17,14 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
         Continue.click();
     }
 
-    @When("User click the consent checkbox")
-    public void user_clicks_on_consent_box() {
+    @When("User clicks the DVA consent checkbox")
+    public void user_clicks_on_DVA_consent_box() {
         consentDVACheckbox.click();
+    }
+
+    @When("User clicks the DVLA consent checkbox")
+    public void user_clicks_on_DVLA_consent_box() {
+        consentDVLACheckbox.click();
     }
 
     @Then("User clicks selects the Yes Radio Button")
@@ -75,6 +80,11 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     @Then("^I see the give your consent error in the summary as (.*)$")
     public void noConsentGivenErrorMessageIsDisplayed(String expectedText) {
         assertNoConsentGivenInErrorSummary(expectedText);
+    }
+
+    @Then("^I see the DVA give your consent error in the summary as (.*)$")
+    public void noConsentGivenDVAErrorMessageIsDisplayed(String expectedText) {
+        assertNoConsentGivenInDVAErrorSummary(expectedText);
     }
 
     @Then("^I can see the licence number error in the field as (.*)$")

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -1,7 +1,6 @@
 Feature: DVA Auth Source Driving Licence Test
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -10,9 +9,9 @@ Feature: DVA Auth Source Driving Licence Test
     And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-#    And I check the page title is We need to check your driving licence details with the DVA – Prove your identity – GOV.UK
-#    And User click the consent checkbox
-#    When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And User clicks the DVA consent checkbox
+    When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number <personalNumber> same as given Driving Licence
@@ -23,8 +22,7 @@ Feature: DVA Auth Source Driving Licence Test
       | check_details | DVAAuthSourceValidBillyJsonPayload   | 55667788       |
       | check_details | DVAAuthSourceValidKennethJsonPayload | 12345678       |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Validation Test - Invalid Context Values
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -37,8 +35,7 @@ Feature: DVA Auth Source Driving Licence Test
       | check_detail  | DVAAuthSourceValidBillyJsonPayload |
       | invalid_value | DVAAuthSourceValidBillyJsonPayload |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Validation Test - Missing context field directs to default DVA journey
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -60,8 +57,7 @@ Feature: DVA Auth Source Driving Licence Test
       | contextValue | DVADrivingLicenceAuthSourceSubject | personalNumber | DVADrivingLicenceSubject           |
       |              | DVAAuthSourceValidBillyJsonPayload | 55667788       | DVADrivingLicenceSubjectHappyBilly |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Raw JSON Object Validation Tests - Missing Address field in Claimset
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -73,9 +69,7 @@ Feature: DVA Auth Source Driving Licence Test
       | contextValue  | DVADrivingLicenceAuthSourceSubject     |
       | check_details | DVAAuthSourceInvalidKennethJsonPayload |
 
-  #  @staging @integration @uat
-  #  This test will require updating following fix in LIME-1328
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Negative Scenario - Postcode does not match the DVA Stub expected value
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -84,6 +78,9 @@ Feature: DVA Auth Source Driving Licence Test
     And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
     And User clicks selects the Yes Radio Button
     When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And User clicks the DVA consent checkbox
+    When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
@@ -91,8 +88,7 @@ Feature: DVA Auth Source Driving Licence Test
       | contextValue  | DVADrivingLicenceAuthSourceSubject   |
       | check_details | DVAAuthSourceInvalidBillyJsonPayload |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Happy path - User selects No on the check your details are correct page
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -109,21 +105,20 @@ Feature: DVA Auth Source Driving Licence Test
       | check_details | DVAAuthSourceValidBillyJsonPayload   |
       | check_details | DVAAuthSourceValidKennethJsonPayload |
 
-#  #  @staging @integration @uat
-#  @build @smoke @stub
-#  Scenario Outline: DVA Auth Source - Error Validation Text - Fail to provide consent
-#    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
-#    And I enter the context value <contextValue> in the Input context value as a string
-#    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
-#    And I add a cookie to change the language to English
-#    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
-#    And User clicks selects the Yes Radio Button
-#    When User clicks on continue
-##    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
-##    When User clicks on continue
-##    And I see the give your consent error in the summary as You must give your consent to continue
-#    And The test is complete and I close the driver
-#    Examples:
-#      | contextValue  | DVADrivingLicenceAuthSourceSubject   |
-#      | check_details | DVAAuthSourceValidBillyJsonPayload   |
-#      | check_details | DVAAuthSourceValidKennethJsonPayload |
+  @build @smoke @stub @staging @integration @uat
+  Scenario Outline: DVA Auth Source - Error Validation Text - Fail to provide consent
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the Yes Radio Button
+    When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    When User clicks on continue
+    And I see the DVA give your consent error in the summary as Error: You must give your consent to continue
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject   |
+      | check_details | DVAAuthSourceValidBillyJsonPayload   |
+      | check_details | DVAAuthSourceValidKennethJsonPayload |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -1,7 +1,6 @@
 Feature: DVLA Auth Source Driving Licence Test
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -10,9 +9,9 @@ Feature: DVLA Auth Source Driving Licence Test
     And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-#    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
-#    And User click the consent checkbox
-#    When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And User clicks the DVLA consent checkbox
+    When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number DECER607085K99AE same as given Driving Licence
@@ -22,8 +21,7 @@ Feature: DVLA Auth Source Driving Licence Test
       | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
       | check_details | DVLAAuthSourceValidKennethJsonPayload |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVLA Auth Source - Validation Test - Invalid Context Values
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -36,8 +34,7 @@ Feature: DVLA Auth Source Driving Licence Test
       | check_detail  | DVLAAuthSourceValidKennethJsonPayload |
       | invalid_value | DVLAAuthSourceValidKennethJsonPayload |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVLA Auth Source - Validation Test - Missing context field directs to default DVLA journey
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -59,8 +56,7 @@ Feature: DVLA Auth Source Driving Licence Test
       | contextValue | DVLADrivingLicenceAuthSourceSubject   | personalNumber   | DVLADrivingLicenceSubject         |
       |              | DVLAAuthSourceValidKennethJsonPayload | DECER607085K99AE | DrivingLicenceSubjectHappyKenneth |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVLA Auth Source - Raw JSON Object Validation Tests - Missing Address field in Claimset
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -72,8 +68,8 @@ Feature: DVLA Auth Source Driving Licence Test
       | contextValue  | DVLADrivingLicenceAuthSourceSubject              |
       | check_details | DVLAAuthSourceInvalidKennethJsonPayloadNoAddress |
 
-  #  @staging @integration @uat
-  @build @smoke @stub
+
+  @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -89,20 +85,20 @@ Feature: DVLA Auth Source Driving Licence Test
       | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
       | check_details | DVLAAuthSourceValidKennethJsonPayload |
 
-#  #  @staging @integration @uat
-#  @build @smoke @stub
-#  Scenario Outline: DVLA Auth Source - Error Validation Text - Fail to provide consent
-#    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
-#    And I enter the context value <contextValue> in the Input context value as a string
-#    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
-#    And I add a cookie to change the language to English
-#    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
-#    And User clicks selects the Yes Radio Button
-#    When User clicks on continue
-##    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
-##    When User clicks on continue
-##    And I see the give your consent error in the summary as You must give your consent to continue
-#    And The test is complete and I close the driver
-#    Examples:
-#      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
-#      | check_details | DVLAAuthSourceValidKennethJsonPayload |
+
+  @build @smoke @stub @staging @integration @uat
+  Scenario Outline: DVLA Auth Source - Error Validation Text - Fail to provide consent
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the Yes Radio Button
+    When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    When User clicks on continue
+    And I see the give your consent error in the summary as Error: You must give your consent to continue
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVLADrivingLicenceAuthSourceSubject   |
+      | check_details | DVLAAuthSourceValidKennethJsonPayload |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Changes made to auth source feature tests to ensure they correctly test DL auth source consent screen. 

All auth source feature tests now passing correctly. 

### Why did it change

The tests in question had been created prior to the DL auth source consent screen being created so some tweaking of the tests was required once the consent screen had been created. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1328](https://govukverify.atlassian.net/browse/LIME-1328)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1328]: https://govukverify.atlassian.net/browse/LIME-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ