### PR TITLE
LIME-1383: Updated Failing API Retry Test and Failing UAT Postcode validation FE Test

### DIFF
--- a/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidJsonPayload.json
+++ b/acceptance-tests/src/test/resources/Data/DVAAuthSourceInvalidJsonPayload.json
@@ -1,0 +1,10 @@
+{
+  "drivingLicenceNumber": "12345678",
+  "postcode": "BA2 5AB",
+  "licenceIssuer": "DVA",
+  "surname": "DECERQUEIRA",
+  "forenames": "KENNETH",
+  "dateOfBirth": "1965-07-08",
+  "issueDate": "2018-04-19",
+  "expiryDate": "2042-10-01"
+}

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
@@ -19,18 +19,19 @@ Feature: DVA CRI API
       | check_details | 12345678       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH BA2 5AA          | DVAAuthValidKennethJsonPayload |
       | check_details | 55667788       | 2042-10-01 | 2018-04-19 | DVA      | 70 OLD BAKERS COURT BELFAST NW3 5RG | DVAAuthValidBillyJsonPayload   |
 
-#  @drivingLicenceCRI_API @pre-merge @dev
-#  Scenario Outline: DVA Driving Licence - Auth Source Retry Journey Happy Path
-#    Given DVA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
-#    And Driving Licence user sends a POST request to session endpoint
-#    And Driving Licence user gets a session-id
-#    And Driving Licence user sends a GET request to the personInfo endpoint
-#    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
-#    Then Driving Licence check response should contain Retry value as false
-#    Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
-#    Examples:
-#      | context       | personalNumber | expiryDate | issueDate  | issuedBy | fullAddress                | JSONPayloadRequest    | cri_internal_error_code | cri_internal_error_message    |
-#      | check_details | 12345678       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH BA2 5AA | DVAInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario Outline: DVA Driving Licence - Auth Source Retry Journey Happy Path
+    Given DVA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
+    Then Driving Licence check response should contain Retry value as false
+    Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
+    Examples:
+      | context       | personalNumber | expiryDate | issueDate  | issuedBy | fullAddress                | JSONPayloadRequest              | cri_internal_error_code | cri_internal_error_message    |
+      | check_details | 12345678       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH BA2 5AA | DVAAuthSourceInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+      | check_details | 66778899       | 2042-10-01 | 2018-04-19 | DVA      | 8 HADLEY ROAD BATH NW3 5RG | DVAAuthSourceInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+
 
   @drivingLicenceCRI_API @pre-merge @dev
   Scenario: DVA Driving Licence Happy path

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -69,7 +69,7 @@ Feature: DVA Auth Source Driving Licence Test
       | contextValue  | DVADrivingLicenceAuthSourceSubject     |
       | check_details | DVAAuthSourceInvalidKennethJsonPayload |
 
-  @build @smoke @stub @staging @integration @uat
+  @build @smoke @stub
   Scenario Outline: DVA Auth Source - Negative Scenario - Postcode does not match the DVA Stub expected value
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -87,6 +87,27 @@ Feature: DVA Auth Source Driving Licence Test
     Examples:
       | contextValue  | DVADrivingLicenceAuthSourceSubject   |
       | check_details | DVAAuthSourceInvalidBillyJsonPayload |
+
+  @staging @integration @uat
+  Scenario Outline: DVA Auth Source - Negative Scenario UAT Stub - Postcode does not match the DVA Stub expected value
+    Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
+    And I enter the context value <contextValue> in the Input context value as a string
+    And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I add a cookie to change the language to English
+    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And User clicks selects the Yes Radio Button
+    When User clicks on continue
+    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And User clicks the DVA consent checkbox
+    When User clicks on continue
+    Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
+    And JSON payload should contain validity score 0, strength score 3 and type IdentityCheck
+    And JSON response should contain personal number <personalNumber> same as given Driving Licence
+    And JSON response should contain JTI field
+    And The test is complete and I close the driver
+    Examples:
+      | contextValue  | DVADrivingLicenceAuthSourceSubject   | personalNumber |
+      | check_details | DVAAuthSourceInvalidBillyJsonPayload | 55667788       |
 
   @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Happy path - User selects No on the check your details are correct page

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
@@ -19,24 +19,22 @@ Feature: DrivingLicence CRI API
       | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH TB2 5AA | DVLAValidKennethJsonPayload |
       | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH BA2 5AA | DVLAValidKennethJsonPayload |
 
-#  @drivingLicenceCRI_API @pre-merge @dev
-#  Scenario Outline: DVLA Driving Licence - Auth Source Retry Journey Happy Path
-#    Given DVLA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issueNumber>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
-#    And Driving Licence user sends a POST request to session endpoint
-#    And Driving Licence user gets a session-id
-#    And Driving Licence user sends a GET request to the personInfo endpoint
-#    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
-#    Then Driving Licence check response should contain Retry value as true
-#    And Driving Licence user gets authorisation code
-#    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
-#    Then User requests Driving Licence CRI VC
-#    And Driving Licence VC should contain validityScore 2 and strengthScore 3
-#    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
-#    And Driving Licence VC should contain JTI field
-##    Then Check response contains unexpected server error exception containing debug error code <cri_internal_error_code> and debug error message <cri_internal_error_message>
-#    Examples:
-#      | context       | personalNumber   | expiryDate | issueDate  | issueNumber | issuedBy | fullAddress                | JSONPayloadRequest     | cri_internal_error_code | cri_internal_error_message    |
-#      | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH TB2 5AA | DVLAInvalidJsonPayload | 1229                    | Failed to unwrap DVA response |
+  @drivingLicenceCRI_API @pre-merge @dev
+  Scenario Outline: DVLA Driving Licence - Auth Source Retry Journey Happy Path
+    Given DVLA Driving Licence with a signed JWT string with <context>, <personalNumber>, <expiryDate>, <issueDate>, <issueNumber>, <issuedBy> and <fullAddress> for CRI Id driving-licence-cri-dev and JSON Shared Claims 197
+    And Driving Licence user sends a POST request to session endpoint
+    And Driving Licence user gets a session-id
+    When Driving Licence user sends a POST request to Driving Licence endpoint using updated jsonRequest returned from the personInfo Table <JSONPayloadRequest>
+    Then Driving Licence check response should contain Retry value as true
+    And Driving Licence user gets authorisation code
+    And Driving Licence user sends a POST request to Access Token endpoint driving-licence-cri-dev
+    Then User requests Driving Licence CRI VC
+    And Driving Licence VC should contain validityScore 0 and strengthScore 3
+    And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in failedCheckDetails checkDetails
+    And Driving Licence VC should contain JTI field
+    Examples:
+      | context       | personalNumber   | expiryDate | issueDate  | issueNumber | issuedBy | fullAddress                | JSONPayloadRequest     |
+      | check_details | DOE99751010AL9OD | 2022-02-02 | 2012-02-02 | 13          | DVLA     | 8 HADLEY ROAD BATH TB2 5AA | DVLAInvalidJsonPayload |
 
 
   @drivingLicenceCRI_API @pre-merge @dev


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated API Tests for Auth Source - Scenario for Retry for DVA and DVLA now pass as expected
Updated FE Tests for Auth Source - Scenario for Postcode mismatch on UAT Staging environment added and split from the Smoke/ Build Test

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1383](https://govukverify.atlassian.net/browse/LIME-1383)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1383]: https://govukverify.atlassian.net/browse/LIME-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ