### PR TITLE
IPS-1112: Add alias permissions to lambda functions for canary deploy…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -206,14 +206,14 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 880
+        "line_number": 901
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 887
+        "line_number": 908
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -476,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-30T14:26:45Z"
+  "generated_at": "2024-12-16T15:25:03Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -693,6 +693,13 @@ Resources:
       FunctionName: !GetAtt DrivingPermitCheckingFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  DrivingPermitCheckingFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref DrivingPermitCheckingFunction.Alias
+      Principal: apigateway.amazonaws.com
+
 ####################################################################
 #                                                                  #
 # Issue Credential Function                                        #
@@ -787,6 +794,13 @@ Resources:
       FunctionName: !GetAtt IssueCredentialFunction.Arn
       Principal: apigateway.amazonaws.com
 
+  IssueCredentialFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref IssueCredentialFunction.Alias
+      Principal: apigateway.amazonaws.com
+
   ####################################################################
   #                                                                  #
   # Person Info Function                                        #
@@ -843,6 +857,13 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt PersonInfoFunction.Arn
+      Principal: apigateway.amazonaws.com
+
+  PersonInfoFunctionAliasPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref PersonInfoFunction.Alias
       Principal: apigateway.amazonaws.com
 
   ####################################################################


### PR DESCRIPTION
- When deploy the canary without the lambda permissions for alias causes a rollback

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes
- Changes are made for lambda canary deployments and tested with the traffic test on the dev environment. When the lambda permissions for alias are created beforehand causes a rollback as the code deploy started without the alias permissions and send traffic to the green versions causes a rollback.

### What changed
- API Gateway is pointing to the blue version which has permissions for the lambda functions. 
- When deployed a canary for lambda functions, part of the traffic is routed to the green version which is deployed on the same PR. 
- Created a new PR first to deploy the permissions to alias version before enable canary deployment. 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [IPS-1112](https://govukverify.atlassian.net/browse/IPS-1112)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[IPS-1112]: https://govukverify.atlassian.net/browse/IPS-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ