### PR TITLE
LIME-1203 custom metric alarm created for DVA

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -2921,9 +2921,9 @@ Resources:
       AlarmActions:
         - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: [ ]
-      EvaluationPeriods: 1
-      DatapointsToAlarm: 1
-      Threshold: 1
+      EvaluationPeriods: 1440
+      DatapointsToAlarm: 2
+      Threshold: 2
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:
@@ -2939,7 +2939,7 @@ Resources:
               MetricName: dva_third_party_api_dva_endpoint_api_response_type_unexpected_http_status
               Dimensions:
                 - Name: Service
-                  Value: "di-ipv-cri-dl-api-drivingpermitcheck"
+                  Value: !Sub "${CriIdentifier}-drivingpermitcheck"
             Period: 60
             Stat: Sum
         - Id: errorResponse
@@ -2950,7 +2950,7 @@ Resources:
               MetricName: dva_third_party_api_dva_endpoint_api_response_type_error
               Dimensions:
                 - Name: Service
-                  Value: "di-ipv-cri-dl-api-drivingpermitcheck"
+                  Value: !Sub "${CriIdentifier}-drivingpermitcheck"
             Period: 60
             Stat: Sum
 

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -2910,6 +2910,50 @@ Resources:
             Period: 60
             Stat: Sum
 
+  DVAThirdPartyApiErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-DVAThirdPartyApiErrorAlarm"
+      AlarmDescription: !Sub "There has been a significant proportion of errors on the DVA third party endpoint ${SupportManualURL}"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-critical-alert-topic
+      AlarmActions:
+        - !ImportValue platform-alarm-critical-alert-topic
+      InsufficientDataActions: [ ]
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: SUM([unexpectedStatus, errorResponse])
+        - Id: unexpectedStatus
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: dva_third_party_api_dva_endpoint_api_response_type_unexpected_http_status
+              Dimensions:
+                - Name: Service
+                  Value: "di-ipv-cri-dl-api-drivingpermitcheck"
+            Period: 60
+            Stat: Sum
+        - Id: errorResponse
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${CriIdentifier}"
+              MetricName: dva_third_party_api_dva_endpoint_api_response_type_error
+              Dimensions:
+                - Name: Service
+                  Value: "di-ipv-cri-dl-api-drivingpermitcheck"
+            Period: 60
+            Stat: Sum
+
   DrivingPermitCheckingThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Create an alarm to identify DVA third party api errors.

### What changed

Added alarm (DVAThirdPartyApiErrorAlarm) definition to template.yaml

### Why did it change

The aim is to be able to trace errors to the DVA api

Alarm configuration was tested by writing to the metric using an aws cli command (see [LIME-1203](https://govukverify.atlassian.net/browse/LIME-1203) for details).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1203](https://govukverify.atlassian.net/browse/LIME-1203)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1203]: https://govukverify.atlassian.net/browse/LIME-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ