### PR TITLE
LIME-1229 updates dependabot grouping and PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     target-branch: main
     labels:
       - dependabot
+    open-pull-requests-limit: 20
+    groups:
+      aws_powertools:
+        patterns:
+          - "aws_powertools_*"
     commit-message:
       prefix: BAU
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Changes made to:

1. Update grouping in dependabot.yml to ensure dependencies that are required to be kept at the same version number as each other are updated together by dependabot automatically rather than creating an individual PR for each dependency.  
2. Update dependabot open PR limit to 20 due to present limit of 5 being too few given some PRs can be blocked for some time. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1229](https://govukverify.atlassian.net/browse/LIME-1229)


[LIME-1229]: https://govukverify.atlassian.net/browse/LIME-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ