### PR TITLE
LIME-1520 DVA AC test fixes

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -146,6 +146,9 @@ public class DrivingLicencePageObject extends UniversalSteps {
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/div/p")
     public WebElement pageDescriptionHeading;
 
+    @FindBy(xpath = "//*[@id=\"cookies-banner-main\"]")
+    public WebElement cookieBanner;
+
     @FindBy(xpath = "/html/body/div[2]/div/p/strong")
     public WebElement betaBanner;
 
@@ -506,6 +509,10 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     // Should be seperate page
 
+    public void cookieBannerIsDisplayed() {
+        BrowserUtils.waitForVisibility(cookieBanner, 10);
+    }
+
     public void betaBanner() {
         betaBanner.isDisplayed();
     }
@@ -516,6 +523,7 @@ public class DrivingLicencePageObject extends UniversalSteps {
     }
 
     public void rejectAnalysisCookie(String rejectAnalysis) {
+        BrowserUtils.waitForVisibility(rejectAnalysisButton, 10);
         rejectAnalysisButton.click();
     }
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
@@ -298,6 +298,7 @@ public class DrivingLicenceStepDefs extends DrivingLicencePageObject {
 
     @And("^I select (.*) cookie$")
     public void selectRejectAnalysisCookie(String rejectAnalysis) {
+        cookieBannerIsDisplayed();
         rejectAnalysisCookie(rejectAnalysis);
     }
 

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -17,12 +17,12 @@ Feature: DVA Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
-    And JSON response should contain personal number 55667788 same as given Driving Licence
+    And JSON response should contain personal number 12345678 same as given Driving Licence
     And JSON response should contain JTI field
     And The test is complete and I close the driver
     Examples:
       | DVADrivingLicenceSubject           |
-      | DVADrivingLicenceSubjectHappyBilly |
+      | DVADrivingLicenceSubjectHappyKenneth |
 
   @DVADrivingLicence_test
   Scenario Outline: DVA - User attempts journey with invalid details and returns authorisation error
@@ -35,7 +35,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject              |
       | DVADrivingLicenceSubjectUnhappySelina |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub
   Scenario Outline: DVA - User enters invalid driving licence number
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA license number as <InvalidLicenceNumber>
@@ -78,7 +78,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLastName |
       | DVADrivingLicenceSubjectHappyBilly | KYLE            |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub
   Scenario Outline: DVA - User enters invalid issue date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA issue day as <InvalidLicenceIssueDay>
@@ -94,7 +94,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLicenceIssueDay | InvalidLicenceIssueMonth | InvalidLicenceIssueYear |
       | DVADrivingLicenceSubjectHappyBilly | 14                     | 09                       | 2019                    |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub
   Scenario Outline: DVA - User enters invalid valid-to date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
@@ -110,7 +110,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
       | DVADrivingLicenceSubjectHappyBilly | 04                | 08                  | 2032               |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub
   Scenario Outline: DVA - User enters invalid postcode and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     Given User re-enters postcode as <InvalidPostcode>
@@ -124,8 +124,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidPostcode |
       | DVADrivingLicenceSubjectHappyBilly | E20 2AQ         |
 
-
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub
   Scenario Outline: DVA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -139,7 +138,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           |
       | DVADrivingLicenceSubjectHappyBilly |
 
-  @build @staging @integration @stub @uat @smoke
+  @build @staging @integration @stub @smoke
   Scenario Outline: DVA - User attempts invalid journey and retries with invalid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -273,9 +272,9 @@ Feature: DVA Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
-    And JSON response should contain personal number 55667788 same as given Driving Licence
+    And JSON response should contain personal number 12345678 same as given Driving Licence
     And JSON response should contain JTI field
     And The test is complete and I close the driver
     Examples:
-      | DVADrivingLicenceSubject           |
-      | DVADrivingLicenceSubjectHappyBilly |
+      | DVADrivingLicenceSubject             |
+      | DVADrivingLicenceSubjectHappyKenneth |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -19,7 +19,6 @@ Feature: DVA Auth Source Driving Licence Test
     And The test is complete and I close the driver
     Examples:
       | contextValue  | DVADrivingLicenceAuthSourceSubject   | personalNumber |
-      | check_details | DVAAuthSourceValidBillyJsonPayload   | 55667788       |
       | check_details | DVAAuthSourceValidKennethJsonPayload | 12345678       |
 
   @build @smoke @stub @staging @integration @uat
@@ -54,8 +53,8 @@ Feature: DVA Auth Source Driving Licence Test
     And JSON response should contain JTI field
     And The test is complete and I close the driver
     Examples:
-      | contextValue | DVADrivingLicenceAuthSourceSubject | personalNumber | DVADrivingLicenceSubject           |
-      |              | DVAAuthSourceValidBillyJsonPayload | 55667788       | DVADrivingLicenceSubjectHappyBilly |
+      | contextValue | DVADrivingLicenceAuthSourceSubject   | personalNumber | DVADrivingLicenceSubject             |
+      |              | DVAAuthSourceValidKennethJsonPayload | 12345678       | DVADrivingLicenceSubjectHappyKenneth |
 
   @build @smoke @stub @staging @integration @uat
   Scenario Outline: DVA Auth Source - Raw JSON Object Validation Tests - Missing Address field in Claimset


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

	- Switched to Kenneth for HappyPath tests.
	- Switched to Kenneth where appropriate for unhappy path tests.
	- Untagged test that are not valid against the UAT due to miss-matched test users
	- Fix for race condition checking the cookie banner before it is loaded.

### Why did it change

To match thirdparty uat test users.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1520](https://govukverify.atlassian.net/browse/LIME-1520)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1520]: https://govukverify.atlassian.net/browse/LIME-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ