### PR TITLE
LIME-1520 Fix Illegal chars in OAuth response

### DIFF
--- a/lambdas/personInfo/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/PersonInfoHandler.java
+++ b/lambdas/personInfo/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/PersonInfoHandler.java
@@ -198,7 +198,7 @@ public class PersonInfoHandler
             LOGGER.debug(e.getMessage(), e);
             return ApiGatewayResponseGenerator.proxyJsonResponse(
                     HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR, e.getMessage()));
+                    new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR));
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Fix crash due to invalid chars in OAuth response

### Why did it change

An exception was being return in the OAuth Error.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1520](https://govukverify.atlassian.net/browse/LIME-1520)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1520]: https://govukverify.atlassian.net/browse/LIME-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ