### PR TITLE
LIME-1520 Tag only tests that are expected to result in a VC for canary traffic tests

### DIFF
--- a/acceptance-tests/run-traffic-tests.sh
+++ b/acceptance-tests/run-traffic-tests.sh
@@ -34,7 +34,7 @@ echo "ENVIRONMENT ${ENVIRONMENT}"
 echo "STACK_NAME ${STACK_NAME}"
 
 if [ "${STACK_NAME}" != "local" ]; then
-  export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
+  export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TrafficTestTag" | jq -r ".Parameter.Value")
 
   PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl)
   tLen=${#PARAMETERS_NAMES[@]}
@@ -51,20 +51,13 @@ else
   export JOURNEY_TAG="${TEST_TAG}"
 fi
 
-pushd /home/gradle
-gradle cucumber -P tags=${JOURNEY_TAG}
-popd
+for i in $(seq 1 4);
+do
+  pushd /home/gradle
+  gradle cucumber -P tags=${JOURNEY_TAG}
+  popd
 
-sleep 2
-
-pushd /home/gradle
-gradle cucumber -P tags=${JOURNEY_TAG}
-popd
-
-sleep 2
-
-pushd /home/gradle
-gradle cucumber -P tags=${JOURNEY_TAG}
-popd
+  sleep 2
+done
 
 cp -r /home/gradle/build/test-results "$REPORT_DIR"

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -11,7 +11,7 @@ Feature: DVA Driving Licence Test
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     And I see a form requesting DVA LicenceNumber
 
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario Outline: DVA - Happy path
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -35,7 +35,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject              |
       | DVADrivingLicenceSubjectUnhappySelina |
 
-  @build @staging @integration @stub
+  @build @staging @integration @stub @traffic
   Scenario Outline: DVA - User enters invalid driving licence number
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA license number as <InvalidLicenceNumber>
@@ -50,7 +50,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLicenceNumber |
       | DVADrivingLicenceSubjectHappyBilly | 88776655             |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVA - User enters invalid first name and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters first name as <InvalidFirstName>
@@ -64,7 +64,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidFirstName |
       | DVADrivingLicenceSubjectHappyBilly | SELINA           |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVA - User enters invalid last name and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
@@ -78,7 +78,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLastName |
       | DVADrivingLicenceSubjectHappyBilly | KYLE            |
 
-  @build @staging @integration @stub
+  @build @staging @integration @stub @traffic
   Scenario Outline: DVA - User enters invalid issue date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA issue day as <InvalidLicenceIssueDay>
@@ -94,7 +94,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLicenceIssueDay | InvalidLicenceIssueMonth | InvalidLicenceIssueYear |
       | DVADrivingLicenceSubjectHappyBilly | 14                     | 09                       | 2019                    |
 
-  @build @staging @integration @stub
+  @build @staging @integration @stub @traffic
   Scenario Outline: DVA - User enters invalid valid-to date and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
@@ -110,7 +110,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
       | DVADrivingLicenceSubjectHappyBilly | 04                | 08                  | 2032               |
 
-  @build @staging @integration @stub
+  @build @staging @integration @stub @traffic
   Scenario Outline: DVA - User enters invalid postcode and returns could not find your details error message
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     Given User re-enters postcode as <InvalidPostcode>
@@ -124,7 +124,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidPostcode |
       | DVADrivingLicenceSubjectHappyBilly | E20 2AQ         |
 
-  @build @staging @integration @smoke @stub
+  @build @staging @integration @smoke @stub @traffic
   Scenario Outline: DVA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -138,7 +138,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           |
       | DVADrivingLicenceSubjectHappyBilly |
 
-  @build @staging @integration @stub @smoke
+  @build @staging @integration @stub @smoke @traffic
   Scenario Outline: DVA - User attempts invalid journey and retries with invalid details
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -153,7 +153,7 @@ Feature: DVA Driving Licence Test
       | DVADrivingLicenceSubject           | InvalidLicenceNumber |
       | DVADrivingLicenceSubjectHappyBilly | 88776655             |
 
-  @build @staging @integration @stub @uat @smoke
+  @build @staging @integration @stub @uat @smoke @traffic
   Scenario: DVA - User attempts invalid journey and cancels after first attempt
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -230,7 +230,7 @@ Feature: DVA Driving Licence Test
     And The test is complete and I close the driver
 
     #not existing in front end repo
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario Outline: DVA - User attempts journey with invalid details and clicks on prove another way and generates a VC
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA license number as <InvalidLicenceNumber>
@@ -264,7 +264,7 @@ Feature: DVA Driving Licence Test
     Then I see the DVA privacy notice link the DVA privacy notice (opens in a new tab)
     And The test is complete and I close the driver
 
-  @build @stub @Language-regression
+  @build @stub @Language-regression @traffic
   Scenario Outline: Language Title validation
     Given User clicks on language toggle and switches to Welsh
     Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -1,6 +1,6 @@
 Feature: DVA Auth Source Driving Licence Test
 
-  @build @smoke @stub @staging @integration @uat
+  @build @smoke @stub @staging @integration @uat @traffic
   Scenario Outline: DVA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -34,7 +34,7 @@ Feature: DVA Auth Source Driving Licence Test
       | check_detail  | DVAAuthSourceValidBillyJsonPayload |
       | invalid_value | DVAAuthSourceValidBillyJsonPayload |
 
-  @build @smoke @stub @staging @integration @uat
+  @build @smoke @stub @staging @integration @uat @traffic
   Scenario Outline: DVA Auth Source - Validation Test - Missing context field directs to default DVA journey
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
@@ -11,7 +11,7 @@ Feature: Driving Licence Test
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
     And I see a form requesting DVLA LicenceNumber
 
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario Outline: DVLA - Happy path
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -23,7 +23,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             |
       | DrivingLicenceSubjectHappyKenneth |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVLA - User enters invalid driving licence number
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters license number as <InvalidLicenceNumber>
@@ -64,7 +64,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             | InvalidBirthDay | InvalidBirthMonth | InvalidBirthYear |
       | DrivingLicenceSubjectHappyKenneth | 12              | 08                | 1985             |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVLA - User enters invalid last name and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters last name as <InvalidLastName>
@@ -78,7 +78,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             | InvalidLastName |
       | DrivingLicenceSubjectHappyKenneth | KYLE            |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVLA - User enters invalid issue date and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters issue day as <InvalidLicenceIssueDay>
@@ -94,7 +94,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             | InvalidLicenceIssueDay | InvalidLicenceIssueMonth | InvalidLicenceIssueYear |
       | DrivingLicenceSubjectHappyKenneth | 14                     | 09                       | 2019                    |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVLA - User enters invalid valid-to date and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters valid to day as <InvalidValidToDay>
@@ -110,7 +110,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear |
       | DrivingLicenceSubjectHappyKenneth | 04                | 08                  | 2032               |
 
-  @build @staging @integration @stub @uat
+  @build @staging @integration @stub @uat @traffic
   Scenario Outline: DVLA - User enters invalid issue number and returns could not find your details error message
     Given User enters DVLA data as a <DrivingLicenceSubject>
     And User re-enters issue day as <InvalidLicenceIssueDay>
@@ -126,7 +126,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             | InvalidLicenceIssueDay | InvalidLicenceIssueMonth | InvalidLicenceIssueYear |
       | DrivingLicenceSubjectHappyKenneth | 14                     | 09                       | 2019                    |
 
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario Outline: DVLA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -140,7 +140,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject             |
       | DrivingLicenceSubjectHappyKenneth |
 
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario Outline: DVLA - User attempts invalid journey and retries with valid details
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -155,7 +155,7 @@ Feature: Driving Licence Test
       | DrivingLicenceSubject           | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyPeter | PARKE610112PBFGI     |
 
-  @build @staging @integration @smoke @stub @uat
+  @build @staging @integration @smoke @stub @uat @traffic
   Scenario: DVLA - User attempts invalid journey and cancels after first attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -197,7 +197,7 @@ Feature: Driving Licence Test
     Then I see the DVLA privacy notice link the DVLA privacy notice (opens in a new tab)
     And The test is complete and I close the driver
 
-  @build @stub @Language-regression
+  @build @stub @Language-regression @traffic
   Scenario Outline: Language Title validation
     Given User clicks on language toggle and switches to Welsh
     Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -1,6 +1,6 @@
 Feature: DVLA Auth Source Driving Licence Test
 
-  @build @smoke @stub @staging @integration @uat
+  @build @smoke @stub @staging @integration @uat @traffic
   Scenario Outline: DVLA Auth Source - Happy path
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
@@ -34,7 +34,7 @@ Feature: DVLA Auth Source Driving Licence Test
       | check_detail  | DVLAAuthSourceValidKennethJsonPayload |
       | invalid_value | DVLAAuthSourceValidKennethJsonPayload |
 
-  @build @smoke @stub @staging @integration @uat
+  @build @smoke @stub @staging @integration @uat @traffic
   Scenario Outline: DVLA Auth Source - Validation Test - Missing context field directs to default DVLA journey
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string


### PR DESCRIPTION
## Proposed changes

### What changed

Tag only tests that are expected to result in a VC for canary traffic tests
- Enable 1 more loop of the ac test to account for reduced tagged tests.

### Why did it change

Error scenarios where being ran as part of the traffic test, causing canaries to auto roll back.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1520](https://govukverify.atlassian.net/browse/LIME-1520)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1520]: https://govukverify.atlassian.net/browse/LIME-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ