### PR TITLE
LIME-1520 Update AC test to assert correct error message

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -488,6 +488,8 @@ public class DrivingLicencePageObject extends UniversalSteps {
     }
 
     public void navigateToDrivingLicenceResponse(String validOrInvalid) {
+        assertURLContains("callback");
+
         if ("Invalid".equalsIgnoreCase(validOrInvalid)) {
             assertPageTitle(STUB_ERROR_PAGE_TITLE, false);
             assertURLContains("callback");

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -62,7 +62,7 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
-    And JSON response should contain error description Internal server error and status code as 302
+    And JSON response should contain error description Unexpected server error and status code as 302
     And The test is complete and I close the driver
     Examples:
       | contextValue  | DVADrivingLicenceAuthSourceSubject     |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -62,7 +62,7 @@ Feature: DVLA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
-    And JSON response should contain error description Internal server error and status code as 302
+    And JSON response should contain error description Unexpected server error and status code as 302
     And The test is complete and I close the driver
     Examples:
       | contextValue  | DVLADrivingLicenceAuthSourceSubject              |


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Update AC tests to assert correct error message and add assertURLContains to check the VC page has loaded before reading contents.

### Why did it change

The error message has change to the Nimbus message.

(assertURLContains) To address flakiness due to a race condition in the tests, where the VC content is being read before the VC page has loaded -  brought in from fraud https://github.com/govuk-one-login/ipv-cri-fraud-api/blob/987ffedf875aee3115612f14c6e0ffa35bb2f865/acceptance-tests/src/test/java/gov/di_ipv_fraud/pages/FraudPageObject.java#L222

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1520](https://govukverify.atlassian.net/browse/LIME-1520)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1520]: https://govukverify.atlassian.net/browse/LIME-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ