### PR TITLE
LIME-1540 Add OpenTelemetry instrumentation re-work gradle builds and Java dependencies

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,77 +143,77 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 163
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 166
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 167
+        "line_number": 169
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 170
+        "line_number": 172
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 173
+        "line_number": 175
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 190
+        "line_number": 195
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 196
+        "line_number": 201
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 209
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 624
+        "line_number": 629
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 928
+        "line_number": 933
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 935
+        "line_number": 940
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -231,7 +231,7 @@
         "filename": "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java",
         "hashed_secret": "272b2480feac66400cb04c993c1f30eebcb85170",
         "is_verified": false,
-        "line_number": 563
+        "line_number": 565
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java": [
@@ -476,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-16T17:51:05Z"
+  "generated_at": "2025-02-21T12:07:11Z"
 }

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
+	id 'io.freefair.aspectj.post-compile-weaving' version '8.12.1'
 }
 
 defaultTasks 'clean', 'build'
@@ -22,11 +22,8 @@ dependencies {
 	var aws_powertools_version = "1.18.0"
 	var java_cucumber_version = "7.20.1"
 	var dependencyVersions = [
-		// ---------------------------------------------------------
-		// cri_common_lib dependencies should match the ipv-cri-lib version
-		// Workaround until dependency resolution is fix.
-		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.1.3",
+
+		cri_common_lib_version             : "4.0.0",
 
 		// CRI_LIB aws
 		aws_sdk_version                    : "2.30.13",
@@ -47,13 +44,14 @@ dependencies {
 		aws_lambda_core_version            : "1.2.1",
 		// Object mapper
 		jackson_version                    : "2.15.0",
-		// Code weaving (lombok+powertools)
+
+		// Code weaving (powertools)
 		aspectjrt_version                  : "1.9.22.1",
 
 		// Test
 		junit_version                      : "5.11.4",
 		hamcrest_version                   : "2.2",
-		mockito_version                    : "4.3.1",
+		mockito_version                    : "5.15.2",
 		// testFixturesImplementation
 
 		// acceptance tests Implementation
@@ -69,17 +67,18 @@ dependencies {
 	]
 
 	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			"com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
+			platform("com.fasterxml.jackson:jackson-bom:${dependencyVersions.jackson_version}"),
+			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+			"com.fasterxml.jackson.core:jackson-databind",
+			"com.fasterxml.jackson.core:jackson-annotations",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
 			"org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"org.hamcrest:hamcrest:${dependencyVersions.hamcrest_version}",
 			"com.google.code.gson:gson:${dependencyVersions.gson_version}",
 			"org.json:json:20240303"
@@ -182,6 +181,10 @@ task smokeTestStaging() {
 			]
 		}
 	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs << "-Xlint" << "-Xlint:-processing"
 }
 
 apply plugin: 'java'

--- a/acceptance-tests/settings.gradle
+++ b/acceptance-tests/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'di-ipv-cri-driving-permit-api-acceptance-tests'
+
+include "acceptance-tests"

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
@@ -46,9 +46,10 @@ Feature: Driving License Test Common
     And The field error copy Error:You must choose an option to continue
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest @build @staging @integration @stub
-  Scenario: Check the Unrecoverable error/ Unknown error in Driving Licence CRI
-    Given I delete the service_session cookie to get the unexpected error
-    When I check the page title is Sorry, there is a problem – Prove your identity – GOV.UK
-    Then I can see the error heading Sorry, there is a problem
-    And The test is complete and I close the driver
+  # see LIME-1578
+#  @DrivingLicenceTest @build @staging @integration @stub
+#  Scenario: Check the Unrecoverable error/ Unknown error in Driving Licence CRI
+#    Given I delete the service_session cookie to get the unexpected error
+#    When I check the page title is Sorry, there is a problem with GOV.UK One Login
+#    Then I can see the error heading Sorry, there is a problem
+#    And The test is complete and I close the driver

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "idea"
 	id "org.sonarqube" version "4.0.0.2929"
 	id "io.freefair.lombok" version "8.10.2"
+	id 'io.freefair.aspectj.post-compile-weaving' version '8.12.1'
 	id "jacoco"
 	id "jacoco-report-aggregation"
 	id "com.diffplug.spotless" version "6.25.0"
@@ -21,11 +22,7 @@ ext {
 	aws_powertools_version = "1.18.0"
 	dependencyVersions = [
 
-		// ---------------------------------------------------------
-		// cri_common_lib dependencies should match the ipv-cri-lib version
-		// Workaround until dependency resolution is fixed.
-		// ---------------------------------------------------------
-		cri_common_lib_version             : "3.1.3",
+		cri_common_lib_version             : "4.0.0",
 
 		// AWS SDK
 		aws_sdk_version                    : "2.30.13",
@@ -49,10 +46,13 @@ ext {
 		jackson_version                    : "2.15.2",
 
 		// GSON used in DCS/DVA pathway remove with DCS removal rework to jackson
-		gson_version						: "2.8.9",
+		gson_version                       : "2.8.9",
 
-		// Code weaving (lombok+powertools)
+		// Code weaving (powertools+lombok)
 		aspectjrt_version                  : "1.9.22.1",
+
+		// Open telemetry
+		opentelemetry_bom_alpha_version    : "2.12.0-alpha",
 
 		// CRI Apache HTTP Client see https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/dependencies.html
 		httpcomponents_core_version        : "4.4.16",
@@ -61,10 +61,12 @@ ext {
 		// password renewal lambda
 		passay_version                     : "1.6.4",
 
+		bouncycastle_bcpkix_version        : "1.78.1",
+
 		// Test
 		junit_version                      : "5.11.4",
 		hamcrest_version                   : "2.2",
-		mockito_version                    : "4.3.1",
+		mockito_version                    : "5.15.2",
 		webcompere_version                 : "2.1.6",
 
 		// testFixturesImplementation
@@ -136,7 +138,9 @@ spotless {
 subprojects {
 	apply plugin: 'org.sonarqube'
 	apply plugin: 'io.freefair.lombok'
+	apply plugin: 'io.freefair.aspectj.post-compile-weaving'
 	apply plugin: "nebula.lint"
+
 	//gradleLint {
 	//	rules=['unused-dependency']
 	//}
@@ -158,6 +162,10 @@ subprojects {
 	plugins.withId('java-library') {
 		sourceCompatibility = "${javaCompatibility.source}"
 		targetCompatibility = "${javaCompatibility.target}"
+	}
+
+	tasks.withType(JavaCompile).configureEach {
+		options.compilerArgs << "-Xlint" << "-Xlint:-processing"
 	}
 
 	task allDeps(type: DependencyReportTask) {}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -8,6 +8,8 @@ Metadata:
         - W2031
         - W1020
         - E3020
+        - W8003
+        - E3031
 
 Parameters:
   VpcStackName:
@@ -173,6 +175,9 @@ Globals:
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
           - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
+        DT_LOGGING_DESTINATION: !If [IsDeployedFromPipeline, "", "stdout"]
+        DT_LOG_COLLECTION_FILTER_MIN_LEVEL: !If [IsDeployedFromPipeline, ERROR , INFO ]
+        DT_LOGGING_JAVA_FLAGS: !If [IsDeployedFromPipeline, !Ref AWS::NoValue, "log-Transformer=true,log-OpenTelemetryUtils=true,log-AsyncClassRetransformer=true,log-ClassValue=true" ]
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO

--- a/lambdas/build.gradle
+++ b/lambdas/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+	id "java"
+}
+
+subprojects {
+	afterEvaluate { subproject ->
+		dependencies {
+			implementation "org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
+					platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+					platform("com.fasterxml.jackson:jackson-bom:${dependencyVersions.jackson_version}"),
+					platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_bom_alpha_version}"),
+					"io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2",
+					"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
+					"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
+					"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
+					"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
+					project(":lib")
+
+			aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
+					"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
+					"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+		}
+	}
+}

--- a/lambdas/certexpiryreminder/build.gradle
+++ b/lambdas/certexpiryreminder/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -17,27 +16,7 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"), project(":lib-dva"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
-			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
-
-	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
-			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
-			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+	implementation project(":lib"), project(":lib-dva")
 
 	testImplementation testFixtures(project(":lib")),
 			testFixtures(this.project),
@@ -45,10 +24,9 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}"
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}"
 
-	testFixturesImplementation "org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"org.apache.httpcomponents:httpcore:${dependencyVersions.httpcomponents_core_version}",
+	testFixturesImplementation "org.apache.httpcomponents:httpcore:${dependencyVersions.httpcomponents_core_version}",
 			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
 }
 

--- a/lambdas/certexpiryreminder/src/main/java/uk/gov/di/ipv/cri/drivingpermit/certreminder/handler/CertExpiryReminderHandler.java
+++ b/lambdas/certexpiryreminder/src/main/java/uk/gov/di/ipv/cri/drivingpermit/certreminder/handler/CertExpiryReminderHandler.java
@@ -34,7 +34,7 @@ public class CertExpiryReminderHandler implements RequestHandler<Object, Object>
     @ExcludeFromGeneratedCoverageReport
     public CertExpiryReminderHandler()
             throws CertificateException, NoSuchAlgorithmException, InvalidKeySpecException {
-        ClientProviderFactory clientProviderFactory = new ClientProviderFactory();
+        ClientProviderFactory clientProviderFactory = new ClientProviderFactory(true, true);
 
         ParameterStoreService parameterStoreService =
                 new ParameterStoreService(clientProviderFactory.getSSMProvider());

--- a/lambdas/drivingpermitcheck/build.gradle
+++ b/lambdas/drivingpermitcheck/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -17,32 +16,7 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"), project(":lib-dva"), project(":lib-dvla"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
-			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:aws-crt-client:${dependencyVersions.aws_sdk_version}",
-			"com.google.code.gson:gson:${dependencyVersions.gson_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:acm:${dependencyVersions.aws_sdk_version}",
-			'org.bouncycastle:bcpkix-jdk15to18:1.78.1'
-
-	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
-			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
-			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+	implementation project(":lib"), project(":lib-dva"), project(":lib-dvla")
 
 	testImplementation testFixtures(project(":lib")),
 			testFixtures(this.project),
@@ -50,14 +24,13 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}",
 			"org.wiremock:wiremock:3.10.0"
 
 	testFixturesImplementation project(":lib"), project(":lib-dvla"),
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
 			"org.apache.httpcomponents:httpcore:${dependencyVersions.httpcomponents_core_version}",
 			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
 }
@@ -75,7 +48,6 @@ test {
 	useJUnitPlatform {
 		excludeTags 'Pact', 'TestKmsEncryption', 'TestKmsVerification','TestToCreateDvaResponseForE2ETest', 'FullE2ECertTest'
 	}
-	testLogging.showStandardStreams = true
 	finalizedBy jacocoTestReport, jacocoTestCoverageVerification
 }
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -107,7 +107,7 @@ public class DrivingPermitHandler
                 createDrivingPermitConfigurationService(serviceFactory);
 
         AcmCertificateService acmCertificateService =
-                new AcmCertificateService(serviceFactory.getAcmClient());
+                new AcmCertificateService(serviceFactory.getClientProviderFactory().getAcmClient());
 
         ThirdPartyAPIServiceFactory thirdPartyAPIServiceFactoryNotAssignedYet =
                 new ThirdPartyAPIServiceFactory(

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java
@@ -518,7 +518,9 @@ class DvaThirdPartyDocumentGatewayTest {
                                                 parameterStoreService,
                                                 serviceFactory.getApacheHTTPClientFactoryService(),
                                                 new AcmCertificateService(
-                                                        serviceFactory.getAcmClient()),
+                                                        serviceFactory
+                                                                .getClientProviderFactory()
+                                                                .getAcmClient()),
                                                 true),
                                         eventProbe,
                                         1),

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -17,33 +16,14 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
-			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}"
-
-	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
-			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
-			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+	implementation project(":lib")
 
 	testImplementation testFixtures(project(":lib")), testFixtures(this.project),
 			"org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"org.hamcrest:hamcrest:${dependencyVersions.hamcrest_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}",
@@ -52,8 +32,7 @@ dependencies {
 			"org.slf4j:slf4j-log4j12:${dependencyVersions.slf4j_log4j12_version}"
 
 	testFixturesImplementation project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}"
+			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}"
 }
 
 tasks.register('buildZip', Zip) {

--- a/lambdas/passwordRenewal/build.gradle
+++ b/lambdas/passwordRenewal/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 }
 
 configurations.all {
@@ -16,34 +15,14 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"), project(":lib-dvla"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
-			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:aws-crt-client:${dependencyVersions.aws_sdk_version}",
-			"org.passay:passay:${dependencyVersions.passay_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
-
-	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
-			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
-			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+	implementation project(":lib"), project(":lib-dvla"),
+			"org.passay:passay:${dependencyVersions.passay_version}"
 
 	testImplementation testFixtures(project(":lib")),"org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}";
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}"
 }
 
 tasks.register('buildZip', Zip) {

--- a/lambdas/passwordRenewal/src/main/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandler.java
+++ b/lambdas/passwordRenewal/src/main/java/uk/gov/di/ipv/cri/drivingpermit/event/handler/PasswordRenewalHandler.java
@@ -57,7 +57,7 @@ public class PasswordRenewalHandler implements RequestHandler<SecretsManagerRota
     @ExcludeFromGeneratedCoverageReport
     public PasswordRenewalHandler() throws JsonProcessingException {
 
-        ClientProviderFactory clientProviderFactory = new ClientProviderFactory();
+        ClientProviderFactory clientProviderFactory = new ClientProviderFactory(true, true);
 
         ParameterStoreService parameterStoreService =
                 new ParameterStoreService(clientProviderFactory.getSSMProvider());

--- a/lambdas/personInfo/build.gradle
+++ b/lambdas/personInfo/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -16,30 +15,14 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
-			"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}"
-
-	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
-			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
-			"software.amazon.lambda:powertools-parameters:${dependencyVersions.aws_powertools_parameters_version}"
+	implementation project(":lib")
 
 	testImplementation testFixtures(project(":lib")), testFixtures(this.project),
 			"org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}",
 			"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}",
@@ -47,8 +30,7 @@ dependencies {
 			"org.slf4j:slf4j-log4j12:${dependencyVersions.slf4j_log4j12_version}"
 
 	testFixturesImplementation project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}"
+			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}"
 }
 
 tasks.register('buildZip', Zip) {

--- a/lib-dva/build.gradle
+++ b/lib-dva/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java-library"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -17,27 +16,9 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"software.amazon.awssdk:acm:${dependencyVersions.aws_sdk_version}",
-			'org.bouncycastle:bcpkix-jdk15to18:1.78.1'
+	api project(":lib"),
+			"software.amazon.awssdk:acm",
+			"org.bouncycastle:bcpkix-jdk15to18:${dependencyVersions.bouncycastle_bcpkix_version}"
 
 	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
 			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
@@ -47,13 +28,12 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"org.hamcrest:hamcrest:${dependencyVersions.hamcrest_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 
-	testFixturesImplementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}"
+	testFixturesImplementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}"
 
 	compileOnly "org.projectlombok:lombok:${dependencyVersions.lombok_version}"
 	annotationProcessor "org.projectlombok:lombok:${dependencyVersions.lombok_version}"

--- a/lib-dva/src/main/resources/log4j2.xml
+++ b/lib-dva/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+<Appenders>
+    <Console name="JsonAppender" target="SYSTEM_OUT">
+        <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
+    </Console>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+        <PatternLayout pattern="%style{%date{DEFAULT}}{yellow}
+      %highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green}
+      %message"/>
+    </Console>
+</Appenders>
+<Loggers>
+    <Logger name="JsonLogger" level="INFO" additivity="false">
+        <AppenderRef ref="JsonAppender"/>
+    </Logger>
+    <Root level="info">
+        <AppenderRef ref="${env:logAppender:-JsonAppender}"/>
+    </Root>
+</Loggers>
+</Configuration>

--- a/lib-dvla/bin/main/log4j2.xml
+++ b/lib-dvla/bin/main/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+<Appenders>
+    <Console name="JsonAppender" target="SYSTEM_OUT">
+        <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
+    </Console>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+        <PatternLayout pattern="%style{%date{DEFAULT}}{yellow}
+      %highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green}
+      %message"/>
+    </Console>
+</Appenders>
+<Loggers>
+    <Logger name="JsonLogger" level="INFO" additivity="false">
+        <AppenderRef ref="JsonAppender"/>
+    </Logger>
+    <Root level="info">
+        <AppenderRef ref="${env:logAppender:-JsonAppender}"/>
+    </Root>
+</Loggers>
+</Configuration>

--- a/lib-dvla/build.gradle
+++ b/lib-dvla/build.gradle
@@ -5,7 +5,6 @@ plugins {
 	id "java-library"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
@@ -17,23 +16,7 @@ configurations.all {
 }
 
 dependencies {
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
-			project(":lib"),
-			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"com.fasterxml.jackson.core:jackson-core",
-			"com.fasterxml.jackson.core:jackson-databind",
-			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
+	api project(":lib")
 
 	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
 			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
@@ -43,13 +26,12 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"org.hamcrest:hamcrest:${dependencyVersions.hamcrest_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 
-	testFixturesImplementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}"
+	testFixturesImplementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}"
 
 	compileOnly "org.projectlombok:lombok:${dependencyVersions.lombok_version}"
 	annotationProcessor "org.projectlombok:lombok:${dependencyVersions.lombok_version}"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,32 +5,29 @@ plugins {
 	id "java-library"
 	id "idea"
 	id "jacoco"
-	id 'io.freefair.aspectj.post-compile-weaving' version '8.4'
 	id 'java-test-fixtures'
 }
 
 dependencies {
-
-	implementation platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+	api "org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
+			platform("software.amazon.awssdk:bom:${dependencyVersions.aws_sdk_version}"),
+			platform("com.fasterxml.jackson:jackson-bom:${dependencyVersions.jackson_version}"),
+			platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${dependencyVersions.opentelemetry_bom_alpha_version}"),
+			"io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2",
 			"uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
 			"com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
-			"software.amazon.awssdk:lambda:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
+			"software.amazon.awssdk:lambda",
+			"software.amazon.awssdk:dynamodb",
+			"software.amazon.awssdk:dynamodb-enhanced",
+			"software.amazon.awssdk:kms",
+			"software.amazon.awssdk:sqs",
+			"software.amazon.awssdk:aws-crt-client",
 			"com.fasterxml.jackson.core:jackson-core",
 			"com.fasterxml.jackson.core:jackson-databind",
 			"com.fasterxml.jackson.core:jackson-annotations",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${dependencyVersions.jackson_version}",
-			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
-			"com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",
-			"com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
-			"software.amazon.awssdk:acm:${dependencyVersions.aws_sdk_version}",
-			"software.amazon.awssdk:aws-crt-client:${dependencyVersions.aws_sdk_version}"
+			"com.fasterxml.jackson.datatype:jackson-datatype-jsr310",
+			"com.fasterxml.jackson.datatype:jackson-datatype-jdk8",
+			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
 
 	aspect "software.amazon.lambda:powertools-logging:${dependencyVersions.aws_powertools_logging_version}",
 			"software.amazon.lambda:powertools-metrics:${dependencyVersions.aws_powertools_metrics_version}",
@@ -40,13 +37,12 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit_version}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
-			"org.mockito:mockito-inline:${dependencyVersions.mockito_version}",
+			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
 			"org.hamcrest:hamcrest:${dependencyVersions.hamcrest_version}",
 			"uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
 			"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 
 	testFixturesImplementation "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib_version}",
-			"org.aspectj:aspectjrt:${dependencyVersions.aspectjrt_version}",
 			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}",
 			"org.apache.httpcomponents:httpclient:${dependencyVersions.httpcomponents_client_version}"
 

--- a/lib/src/main/resources/log4j2.xml
+++ b/lib/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+<Appenders>
+    <Console name="JsonAppender" target="SYSTEM_OUT">
+        <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
+    </Console>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+        <PatternLayout pattern="%style{%date{DEFAULT}}{yellow}
+      %highlight{%-5level}{FATAL=bg_red, ERROR=red, WARN=yellow, INFO=green}
+      %message"/>
+    </Console>
+</Appenders>
+<Loggers>
+    <Logger name="JsonLogger" level="INFO" additivity="false">
+        <AppenderRef ref="JsonAppender"/>
+    </Logger>
+    <Root level="info">
+        <AppenderRef ref="${env:logAppender:-JsonAppender}"/>
+    </Root>
+</Loggers>
+</Configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,5 @@ include "lib",
 		"lambdas:drivingpermitcheck",
 		"lambdas:issuecredential",
 		"lambdas:certexpiryreminder",
-		"acceptance-tests",
 		"lambdas:passwordRenewal",
 		"lambdas:personInfo"


### PR DESCRIPTION
## Proposed changes

### What changed

Add OpenTelemetry instrumentation re-work gradle builds and Java dependencies

 - Enable Java language linting to aid detection of code-smells (warn only)
 - Add Dynatrace logging (enabled in non-pipeline stacks only)
 - Decoupled AC test from CRI Gradle builds
 - Added Jackson bom
 - Updated Mockito from V4 to V5
 - Use ACM Client now provided by CRI 4.0.0

### Why did it change

Add tracing instrumentation to AWS SDK clients.
Correct issues with the AspectJ code weaving setup.
Simplify Jackson dependancy resolution.
Resolve a blocker preventing automatic Mockito updates (dependancies changes)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1540](https://govukverify.atlassian.net/browse/LIME-1540)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1538]: https://govukverify.atlassian.net/browse/LIME-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIME-1540]: https://govukverify.atlassian.net/browse/LIME-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ