### PR TITLE
LIME-1508 corrected pageTitle and tests

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DLProveYourIdentityFullJourneyPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DLProveYourIdentityFullJourneyPageObject.java
@@ -213,7 +213,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
         kennethFirstQuestion.trim();
         System.out.println("kennethFirstQuestion = " + kennethFirstQuestion);
         switch (kennethFirstQuestion) {
-            case "Which provider did you take out a loan with? – Prove your identity – GOV.UK":
+            case "Which provider did you take out a loan with? – GOV.UK One Login":
                 try {
                     if (loanTSBBANKPLC.isDisplayed()) {
                         loanTSBBANKPLC.click();
@@ -226,7 +226,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "What is the outstanding balance of your current mortgage? – Prove your identity – GOV.UK":
+            case "What is the outstanding balance of your current mortgage? – GOV.UK One Login":
                 try {
                     if (OVER35000UPTO60000.isDisplayed()) {
                         OVER35000UPTO60000.click();
@@ -239,7 +239,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "How much is your monthly mortgage payment? – Prove your identity – GOV.UK":
+            case "How much is your monthly mortgage payment? – GOV.UK One Login":
                 try {
                     if (OVER500UPTO600.isDisplayed()) {
                         OVER500UPTO600.click();
@@ -252,7 +252,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "Which lender did you borrow your mortgage from? – Prove your identity – GOV.UK":
+            case "Which lender did you borrow your mortgage from? – GOV.UK One Login":
                 try {
                     if (SANTANDERANMFMORTGAGE.isDisplayed()) {
                         SANTANDERANMFMORTGAGE.click();
@@ -267,7 +267,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "In which year did you move to your current address? – Prove your identity – GOV.UK":
+            case "In which year did you move to your current address? – GOV.UK One Login":
                 try {
                     if (Year2002.isDisplayed()) {
                         Year2002.click();
@@ -280,7 +280,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "How long do you have to pay back your loan? – Prove your identity – GOV.UK":
+            case "How long do you have to pay back your loan? – GOV.UK One Login":
                 BrowserUtils.waitFor(2);
                 try {
                     if (OVER36MONTHSUPTO48MONTHS.isDisplayed()) {
@@ -294,7 +294,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "How much of your loan do you pay back every month? – Prove your identity – GOV.UK":
+            case "How much of your loan do you pay back every month? – GOV.UK One Login":
                 try {
                     if (OVER550UPTO600.isDisplayed()) {
                         OVER550UPTO600.click();
@@ -307,7 +307,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "How much do you have left to pay on your mortgage? – Prove your identity – GOV.UK":
+            case "How much do you have left to pay on your mortgage? – GOV.UK One Login":
                 try {
                     if (UPTO60000.isDisplayed()) {
                         UPTO60000.click();
@@ -320,7 +320,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "How much of your loan do you have left to pay back? – Prove your identity – GOV.UK":
+            case "How much of your loan do you have left to pay back? – GOV.UK One Login":
                 try {
                     if (UPTO6750.isDisplayed()) {
                         UPTO6750.click();
@@ -333,11 +333,11 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "What are the first 2 letters of the first name of the other person on your mortgage? – Prove your identity – GOV.UK":
+            case "What are the first 2 letters of the first name of the other person on your mortgage? – GOV.UK One Login":
                 KA.click();
                 continueButton.click();
                 break;
-            case "Who have you opened a current account with? – Prove your identity – GOV.UK":
+            case "Who have you opened a current account with? – GOV.UK One Login":
                 try {
                     if (TSBBANKPLC.isDisplayed()) {
                         TSBBANKPLC.click();
@@ -350,7 +350,7 @@ public class DLProveYourIdentityFullJourneyPageObject extends UniversalSteps {
                     }
                 }
                 break;
-            case "When was the other person on your mortgage born? – Prove your identity – GOV.UK":
+            case "When was the other person on your mortgage born? – GOV.UK One Login":
                 try {
                     if (February1963.isDisplayed()) {
                         February1963.click();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
@@ -60,7 +60,7 @@ public class DVAEnterYourDetailsExactlyStepDefs extends DVAEnterYourDetailsExact
     }
 
     @Then(
-            "^I should be on the page DVA Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK$")
+            "^I should be on the page DVA Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login$")
     public void i_should_be_on_the_DVA_page() {
         pageTitleDVAValidation();
     }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -163,9 +163,9 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     }
 
     @And(
-            "I should be on `Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK` page")
+            "I should be on `Enter your details exactly as they appear on your UK driving licence - GOV.UK One Login` page")
     public void
-            i_should_be_on_enter_your_details_exactly_as_they_appear_on_your_uk_driving_licence_prove_your_identity_gov_uk_page() {
+            i_should_be_on_enter_your_details_exactly_as_they_appear_on_your_uk_driving_licence_gov_uk_page() {
         Assert.assertTrue(new DrivingLicencePageObject().LicenceNumber.isDisplayed());
     }
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
@@ -188,7 +188,7 @@ public class DrivingLicenceStepDefs extends DrivingLicencePageObject {
     }
 
     @Then(
-            "^I should on the page DVLA Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK$")
+            "^I should on the page DVLA Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login$")
     public void i_should_be_on_the_DVLA_page() {
         pageTitleDVLAValidation();
     }

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
@@ -4,7 +4,7 @@ Feature: Driving License Test Common
     Given I navigate to the IPV Core Stub
     And I click the Driving Licence CRI for the testEnvironment
     Then I search for Driving Licence user number 5 in the Experian table
-    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK
+    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I see ‘Why we need to know this’ component is present
     When I click the drop-down on the component
     Then I see the message begins with We need to make sure is shown

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -5,10 +5,10 @@ Feature: DVA Driving Licence Test
     And I click the Driving Licence CRI for the testEnvironment
     And I search for Driving Licence user number 5 in the Experian table
     And I add a cookie to change the language to English
-    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK
+    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVA as an option
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And I see a form requesting DVA LicenceNumber
 
   @build @staging @integration @smoke @stub @uat @traffic
@@ -195,7 +195,7 @@ Feature: DVA Driving Licence Test
     And User re-enters DVA license number as <InvalidLicenceNumber>
     And User re-enters postcode as <InvalidPostCode>
     When User clicks on continue
-    Then I check the page title is Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    Then I check the page title is Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And The test is complete and I close the driver
     Examples:
       | DVADrivingLicenceSubject           | InvalidLastName | InvalidFirstName | InvalidBirthDay | InvalidBirthMonth | InvalidBirthYear | InvalidIssueDay | InvalidIssueMonth | InvalidIssueYear | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear | InvalidLicenceNumber | InvalidPostCode | Scenario                              |
@@ -267,7 +267,7 @@ Feature: DVA Driving Licence Test
   @build @stub @Language-regression @traffic
   Scenario Outline: Language Title validation
     Given User clicks on language toggle and switches to Welsh
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -6,10 +6,10 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     And User clicks the DVA consent checkbox
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -40,10 +40,10 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK
+    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVA as an option
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And I see a form requesting DVA LicenceNumber
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -74,10 +74,10 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     And User clicks the DVA consent checkbox
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
@@ -93,10 +93,10 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     And User clicks the DVA consent checkbox
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -114,7 +114,7 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the No Radio Button
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
@@ -131,10 +131,10 @@ Feature: DVA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     When User clicks on continue
     And I see the DVA give your consent error in the summary as Error: You must give your consent to continue
     And The test is complete and I close the driver

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVAProveIdentityFullJourney.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVAProveIdentityFullJourney.feature
@@ -10,16 +10,16 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVA Driving Licence Prove Your Identity Full Journey Route Happy Path (STUB)
     And I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters DVA data as a <DVADrivingLicenceSubject>
     And User clicks on continue
     And I enter BA2 5AA in the Postcode field and find address
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    Then I navigate to the page We need to check your details – Prove your identity – GOV.UK
+    Then I navigate to the page We need to check your details – GOV.UK One Login
     And User clicks on continue
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly
@@ -35,9 +35,9 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVA Prove Your Identity Full Journey Route - Retry Test Happy Path
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters invalid Driving Licence DVA details
     And User clicks on continue
     Then Proper error message for Could not find your details is displayed
@@ -47,7 +47,7 @@ Feature: Prove Your Identity Full Journey
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    Then I navigate to the page We need to check your details – Prove your identity – GOV.UK
+    Then I navigate to the page We need to check your details – GOV.UK One Login
     And User clicks on continue
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly
@@ -63,15 +63,15 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVA Prove Your Identity Full Journey Route Unhappy Path - User Failed Second Attempt
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters invalid Driving Licence DVA details
     And User clicks on continue
     Then Proper error message for Could not find your details is displayed
     When User Re-enters DVA data as a <DVADrivingLicenceSubject>
     And User clicks on continue
-    Then I check the page title is Sorry, you’ll need to prove your identity another way – GOV.UK
+    Then I check the page title is Sorry, you’ll need to prove your identity another way – GOV.UK One Login
     And I can see the error heading Sorry, you’ll need to prove your identity another way
     And The test is complete and I close the driver
     Examples:
@@ -81,9 +81,9 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario: DVA Prove Your Identity Full Journey Route - Back Button From DVA Details Entry Screen To Licence Issuer Page
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User click on ‘Back' Link
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And The test is complete and I close the driver

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicence.feature
@@ -5,10 +5,10 @@ Feature: Driving Licence Test
     And I click the Driving Licence CRI for the testEnvironment
     And I search for Driving Licence user number 5 in the Experian table
     And I add a cookie to change the language to English
-    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK
+    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVLA as an option
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And I see a form requesting DVLA LicenceNumber
 
   @build @staging @integration @smoke @stub @uat @traffic
@@ -200,7 +200,7 @@ Feature: Driving Licence Test
   @build @stub @Language-regression @traffic
   Scenario Outline: Language Title validation
     Given User clicks on language toggle and switches to Welsh
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -229,7 +229,7 @@ Feature: Driving Licence Test
     And User re-enters valid issue number as <InvalidIssueNumber>
     And User re-enters postcode as <InvalidPostCode>
     When User clicks on continue
-    Then I check the page title is Error: Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    Then I check the page title is Error: Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And The test is complete and I close the driver
     Examples:
       | DrivingLicenceSubject           | InvalidLastName | InvalidFirstName | InvalidBirthDay | InvalidBirthMonth | InvalidBirthYear | InvalidIssueDay | InvalidIssueMonth | InvalidIssueYear | InvalidValidToDay | InvalidValidToMonth | InvalidValidToYear | InvalidLicenceNumber | InvalidIssueNumber | InvalidPostCode | Scenario                              |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -6,10 +6,10 @@ Feature: DVLA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     And User clicks the DVLA consent checkbox
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -40,10 +40,10 @@ Feature: DVLA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – Prove your identity – GOV.UK
+    Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVLA as an option
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And I see a form requesting DVLA LicenceNumber
     Given User enters DVLA data as a <DVLADrivingLicenceSubject>
     When User clicks on continue
@@ -75,7 +75,7 @@ Feature: DVLA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the No Radio Button
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
@@ -92,10 +92,10 @@ Feature: DVLA Auth Source Driving Licence Test
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
     And I add a cookie to change the language to English
-    And I check the page title is Check your UK photocard driving licence details – Prove your identity – GOV.UK
+    And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
     When User clicks on continue
-    And I check the page title is We need to check your driving licence details – Prove your identity – GOV.UK
+    And I check the page title is We need to check your driving licence details – GOV.UK One Login
     When User clicks on continue
     And I see the give your consent error in the summary as Error: You must give your consent to continue
     And The test is complete and I close the driver

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLAProveIdentityFullJourney.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLAProveIdentityFullJourney.feature
@@ -10,16 +10,16 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVLA Driving Licence Prove Your Identity Full Journey Route Happy Path (STUB)
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters DVLA data as a <DrivingLicenceSubject>
     And User clicks on continue
     And I enter BA2 5AA in the Postcode field and find address
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    Then I navigate to the page We need to check your details – Prove your identity – GOV.UK
+    Then I navigate to the page We need to check your details – GOV.UK One Login
     And User clicks on continue
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly
@@ -35,9 +35,9 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVLA Prove Your Identity Full Journey Route - Retry Test Happy Path
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters invalid Driving Licence DVLA details
     And User clicks on continue
     Then Proper error message for Could not find your details is displayed
@@ -47,7 +47,7 @@ Feature: Prove Your Identity Full Journey
     And the user chooses their address 8 HADLEY ROAD, BATH, BA2 5AA from dropdown and click `Choose address`
     And the user enters the date 2014 they moved into their current address
     And the user clicks `I confirm my details are correct`
-    Then I navigate to the page We need to check your details – Prove your identity – GOV.UK
+    Then I navigate to the page We need to check your details – GOV.UK One Login
     And User clicks on continue
     And the user clicks `Answer security questions`
     And kenneth answers the first question correctly
@@ -63,15 +63,15 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVLA Prove Your Identity Full Journey Route Unhappy Path - User failed Second Attempt
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User enters invalid Driving Licence DVLA details
     And User clicks on continue
     Then Proper error message for Could not find your details is displayed
     When User Re-enters DVLA data as a <DrivingLicenceSubject>
     And User clicks on continue
-    Then I check the page title is Sorry, you’ll need to prove your identity another way – GOV.UK
+    Then I check the page title is Sorry, you’ll need to prove your identity another way – GOV.UK One Login
     And I can see the error heading Sorry, you’ll need to prove your identity another way
     And The test is complete and I close the driver
     Examples:
@@ -81,9 +81,9 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario: DVLA Prove Your Identity Full Journey Route - Back Button From DVLA Details Entry Screen To Licence Issuer Page
     Given I select the radio option UK driving licence and click on Continue
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And I click on DVLA radio button and Continue
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User click on ‘Back' Link
-    And I check the page title is Who was your UK driving licence issued by? – Prove your identity – GOV.UK
+    And I check the page title is Who was your UK driving licence issued by? – GOV.UK One Login
     And The test is complete and I close the driver

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Welsh/WelshLangDrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Welsh/WelshLangDrivingLicence.feature
@@ -16,10 +16,10 @@ Feature: Driving License Language Test
   @Language-regression
   Scenario Outline: DVLA Error tab title validation
     Given I click on DVLA radio button and Parhau
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     Then User enters DVLA data as a <DrivingLicenceSubject>
     And User clicks on continue
-    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -29,10 +29,10 @@ Feature: Driving License Language Test
   @Language-regression
   Scenario: DVAError tab title validation
     Given I click on DVA radio button and Parhau
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     When I enter the invalid Postcode
     And User clicks on continue
-    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – Profi pwy ydych chi – GOV.UK
+    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
     And The test is complete and I close the driver
 
   #not existing in front end repo
@@ -61,7 +61,7 @@ Feature: Driving License Language Test
   Scenario Outline: Language Title validation Welsh DVLA
     Given I click on DVLA radio button and Parhau
     Then User clicks language toggle and switches to English
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Then User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -76,7 +76,7 @@ Feature: Driving License Language Test
   Scenario Outline: Language Title validation Welsh DVA
     Given I click on DVA radio button and Parhau
     Then User clicks language toggle and switches to English
-    And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Then User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

serviceName amended to remove _"... - Prove your identity" from page tab titles in DL FE. BE tests updated to reflect this and the removal adding of 'One Login' to the pageTitle suffix brought in by the Common Express update.

### Why did it change

To keep this service in line with other services of the programme and fix failing tests as a result of the Common Express update beyond 10.1.x.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1591](https://govukverify.atlassian.net/browse/LIME-1591)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1508]: https://govukverify.atlassian.net/browse/LIME-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIME-1591]: https://govukverify.atlassian.net/browse/LIME-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ