### PR TITLE
LIME-1599 Handle race conditions within DL Auth source AC tests.

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -236,6 +236,7 @@ Feature: DVA Driving Licence Test
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA license number as <InvalidLicenceNumber>
     When User clicks on continue
+    And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON response should contain personal number 88776655 same as given Driving Licence

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicenceAuthSource.feature
@@ -40,6 +40,7 @@ Feature: DVA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains licence-issuer
     And I add a cookie to change the language to English
     Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVA as an option
@@ -74,6 +75,7 @@ Feature: DVA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
@@ -93,6 +95,7 @@ Feature: DVA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button
@@ -114,6 +117,7 @@ Feature: DVA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the No Radio Button
@@ -131,6 +135,7 @@ Feature: DVA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLADrivingLicenceAuthSource.feature
@@ -40,6 +40,7 @@ Feature: DVLA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains licence-issuer
     And I add a cookie to change the language to English
     Then I check the page title is Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login
     And I should see DVLA as an option
@@ -75,6 +76,7 @@ Feature: DVLA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the No Radio Button
@@ -92,6 +94,7 @@ Feature: DVLA Auth Source Driving Licence Test
     Given I navigate to the IPV Core Stub and select Driving Licence CRI for the testEnvironment
     And I enter the context value <contextValue> in the Input context value as a string
     And I enter the shared claims raw JSON <DVLADrivingLicenceAuthSourceSubject> in the Input shared claims raw JSON
+    And I assert the url path contains check-your-details
     And I add a cookie to change the language to English
     And I check the page title is Check your UK photocard driving licence details – GOV.UK One Login
     And User clicks selects the Yes Radio Button


### PR DESCRIPTION
## Proposed changes

### What changed

Handle race conditions within DL Auth source AC tests

### Why did it change

To reduce pipeline failures.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1599](https://govukverify.atlassian.net/browse/LIME-1599)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1599]: https://govukverify.atlassian.net/browse/LIME-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ