### PR TITLE
LIME-1626 Add support for new ipv-core client id - "ipv-core-3rd-party-stubs"

### DIFF
--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -47,6 +47,7 @@ jobs:
         uses: govuk-one-login/github-actions/sam/build-application@main
         id: build
         with:
+          sam-version: "1.134.0"
           template: infrastructure/lambda/template.yaml
           cache-name: ipv-cri-dl-api-${{ steps.vars.outputs.sha_short }}
           pull-repository: true

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -763,11 +763,13 @@ public class DrivingLicencePageObject extends UniversalSteps {
     }
 
     public void userNotFoundInThirdPartyErrorIsDisplayed() {
+        BrowserUtils.waitForVisibility(userNotFoundInThirdPartyBanner, 10);
         assertTrue(userNotFoundInThirdPartyBanner.isDisplayed());
         LOGGER.info(userNotFoundInThirdPartyBanner.getText());
     }
 
     public void userNotFoundInThirdPartyErrorIsDisplayedDva() {
+        BrowserUtils.waitForVisibility(userNotFoundInThirdPartyBannerDva, 10);
         assertTrue(userNotFoundInThirdPartyBannerDva.isDisplayed());
         LOGGER.info(userNotFoundInThirdPartyBannerDva.getText());
     }
@@ -1044,83 +1046,103 @@ public class DrivingLicencePageObject extends UniversalSteps {
     }
 
     public void assertInvalidDoBInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidDOBErrorInSummary, 10);
         assertEquals(expectedText, InvalidDOBErrorInSummary.getText());
     }
 
     public void assertInvalidDoBOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidDateOfBirthFieldError, 10);
         assertEquals(expectedText, InvalidDateOfBirthFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidIssueDateInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidIssueDateErrorInSummary, 10);
         assertEquals(expectedText, InvalidIssueDateErrorInSummary.getText());
     }
 
     public void assertInvalidIssueDateOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidIssueDateFieldError, 10);
         assertEquals(expectedText, InvalidIssueDateFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidValidToDateInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidValidToDateErrorInSummary, 10);
         assertEquals(expectedText, InvalidValidToDateErrorInSummary.getText());
     }
 
     public void assertInvalidValidToDateOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidValidToDateFieldError, 10);
         assertEquals(expectedText, InvalidValidToDateFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidLicenceNumberInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidDrivingLicenceErrorInSummary, 10);
         assertEquals(expectedText, InvalidDrivingLicenceErrorInSummary.getText());
     }
 
     public void assertInvalidLicenceNumberOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(DrivingLicenceFieldError, 10);
         assertEquals(expectedText, DrivingLicenceFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidIssueNumberInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidIssueNumberErrorInSummary, 10);
         assertEquals(expectedText, InvalidIssueNumberErrorInSummary.getText());
     }
 
     public void assertInvalidIssueNumberOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidIssueNumberFieldError, 10);
         assertEquals(expectedText, InvalidIssueNumberFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidPostcodeInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidPostcodeErrorInSummary, 10);
         assertEquals(expectedText, InvalidPostcodeErrorInSummary.getText());
     }
 
     public void assertInvalidPostcodeOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidPostcodeFieldError, 10);
         assertEquals(expectedText, InvalidPostcodeFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidLastNameInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidLastNameErrorInSummary, 10);
         assertEquals(expectedText, InvalidLastNameErrorInSummary.getText());
     }
 
     public void assertInvalidLastNameOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidLastNameFieldError, 10);
         assertEquals(expectedText, InvalidLastNameFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidFirstNameInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidFirstNameErrorInSummary, 10);
         assertEquals(expectedText, InvalidFirstNameErrorInSummary.getText());
     }
 
     public void assertInvalidFirstNameOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidFirstNameFieldError, 10);
         assertEquals(expectedText, InvalidFirstNameFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertInvalidMiddleNameInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidMiddleNamesErrorInSummary, 10);
         assertEquals(expectedText, InvalidMiddleNamesErrorInSummary.getText());
     }
 
     public void assertInvalidMiddleNameOnField(String expectedText) {
+        BrowserUtils.waitForVisibility(InvalidMiddleNamesFieldError, 10);
         assertEquals(expectedText, InvalidMiddleNamesFieldError.getText().trim().replace("\n", ""));
     }
 
     public void assertNoConsentGivenInErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(DVLAConsentCheckboxError, 10);
         String formattedErrorText = DVLAConsentCheckboxError.getText().replaceAll("\\s+", " ");
         assertEquals(expectedText, formattedErrorText);
     }
 
     public void assertNoConsentGivenInDVAErrorSummary(String expectedText) {
+        BrowserUtils.waitForVisibility(dvaConsentCheckboxError, 10);
         String formattedErrorText = dvaConsentCheckboxError.getText().replaceAll("\\s+", " ");
         assertEquals(expectedText, formattedErrorText);
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/domain/Strategy.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/domain/Strategy.java
@@ -17,6 +17,7 @@ public enum Strategy {
             case "ipv-core-stub-aws-build_3rdparty" -> UAT;
             case "ipv-core-stub-aws-prod_3rdparty" -> UAT;
             case "ipv-core-stub-pre-prod-aws-build" -> LIVE;
+            case "ipv-core-3rd-party-stubs" -> STUB; // Real ipv-core
             case "ipv-core" -> LIVE;
             default -> NO_CHANGE;
         };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Add support for new ipv-core client id - "ipv-core-3rd-party-stubs"

Fix pre-merge sam build step missing sam-version: "1.134.0" pinning

### Why did it change

ipv-core-3rd-party-stubs - To enable an IPV-Core end to end journey with CRI using third-party stubs

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1626](https://govukverify.atlassian.net/browse/LIME-1626)
- depends on https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/441

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1626]: https://govukverify.atlassian.net/browse/LIME-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ