### PR TITLE
LIME-1669 - Removing unused parameter reads from certExpiryLambda

### DIFF
--- a/lambdas/certexpiryreminder/src/main/java/uk/gov/di/ipv/cri/drivingpermit/certreminder/config/CertExpiryReminderConfig.java
+++ b/lambdas/certexpiryreminder/src/main/java/uk/gov/di/ipv/cri/drivingpermit/certreminder/config/CertExpiryReminderConfig.java
@@ -106,10 +106,6 @@ public class CertExpiryReminderConfig {
                 KeyCertHelper.getDecodedX509Certificate(dvaHeldCertMap.get("tlsRootCert"));
         certMap.put("dvaHeldTlsRootCert", dvaHeldTlsRootCertExpiry);
 
-        X509Certificate dvaHeldTlsIntermediateCertExpiry =
-                KeyCertHelper.getDecodedX509Certificate(dvaHeldCertMap.get("tlsIntermediateCert"));
-        certMap.put("dvaHeldTlsIntermediateCert", dvaHeldTlsIntermediateCertExpiry);
-
         X509Certificate dvaHeldSigningCertExpiry =
                 KeyCertHelper.getDecodedX509Certificate(dvaHeldCertMap.get("dvaSigningCert"));
         certMap.put("dvaHeldSigningCert", dvaHeldSigningCertExpiry);

--- a/lambdas/certexpiryreminder/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/config/CertExpiryReminderConfigTest.java
+++ b/lambdas/certexpiryreminder/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/config/CertExpiryReminderConfigTest.java
@@ -86,8 +86,6 @@ class CertExpiryReminderConfigTest {
                 Map.of(
                         "tlsRootCert",
                         CertAndKeyTestFixtures.TEST_TLS_CRT,
-                        "tlsIntermediateCert",
-                        CertAndKeyTestFixtures.TEST_TLS_CRT,
                         "dvaSigningCert",
                         CertAndKeyTestFixtures.TEST_TLS_CRT,
                         "dvaEncryptionCert",


### PR DESCRIPTION
### What changed

Removed unused parameter reads from certExpiryLambda. TLSIntermediate cert is no longer held by DVA and therefore parameter and reference in certExpiryLambda has been removed as part of this PR
