### PR TITLE
LIME-1662 Increase logging clarity in error pathways and unexpected conditions

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -642,7 +642,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         String requestDrivingLicenceVCResponse = sendHttpRequest(request).body();
         LOGGER.info("requestDrivingLicenceVCResponse = {}", requestDrivingLicenceVCResponse);
         String expectedResponseForInvalidAuthCode =
-                "{\"oauth_error\":{\"error_description\":\"Session not found\",\"error\":\"access_denied\"}}";
+                "{\"oauth_error\":{\"error_description\":\"Access denied by resource owner or authorization server\",\"error\":\"access_denied\"}}";
         assertEquals(expectedResponseForInvalidAuthCode, requestDrivingLicenceVCResponse);
     }
 

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -515,9 +515,7 @@ class DrivingPermitHandlerTest {
                         OAuth2Error.SERVER_ERROR, OAuth2Error.SERVER_ERROR.getDescription());
 
         // Assert CommonExpress OAuth error format
-        assertEquals(
-                "oauth_error",
-                responseTreeRootNode.fieldNames().next().toString()); // Root Node Name
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
         assertEquals(
                 expectedObject.getError().get("error"),
                 oauthErrorNode.get("error").textValue()); // error
@@ -605,7 +603,8 @@ class DrivingPermitHandlerTest {
     }
 
     @Test
-    void handleResponseShouldThrowExceptionWhenSessionIdMissing() throws JsonProcessingException {
+    void handleResponseShouldReturnForbiddenResponseSessionIdMissing()
+            throws JsonProcessingException {
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
@@ -628,9 +627,7 @@ class DrivingPermitHandlerTest {
         assertNotNull(oauthErrorNode);
         assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
 
-        assertEquals(
-                "oauth_error",
-                responseTreeRootNode.fieldNames().next().toString()); // Root Node Name
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
         assertEquals(
                 expectedObject.getError().get("error"),
                 oauthErrorNode.get("error").textValue()); // error
@@ -640,7 +637,42 @@ class DrivingPermitHandlerTest {
     }
 
     @Test
-    void handleResponseShouldThrowExceptionWhenSessionIdIsInvalid() throws JsonProcessingException {
+    void handleResponseShouldReturnForbiddenResponseInputHeadersAreMissing()
+            throws JsonProcessingException {
+        APIGatewayProxyRequestEvent mockRequestEvent =
+                Mockito.mock(APIGatewayProxyRequestEvent.class);
+
+        Map<String, String> headers = null;
+
+        when(mockRequestEvent.getHeaders()).thenReturn(headers);
+
+        APIGatewayProxyResponseEvent responseEvent =
+                drivingPermitHandler.handleRequest(mockRequestEvent, context);
+
+        JsonNode responseTreeRootNode = new ObjectMapper().readTree(responseEvent.getBody());
+        JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
+
+        CommonExpressOAuthError expectedObject =
+                new CommonExpressOAuthError(
+                        OAuth2Error.ACCESS_DENIED, SESSION_NOT_FOUND.getMessage());
+
+        assertNotNull(responseEvent);
+        assertNotNull(responseTreeRootNode);
+        assertNotNull(oauthErrorNode);
+        assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
+
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
+        assertEquals(
+                expectedObject.getError().get("error"),
+                oauthErrorNode.get("error").textValue()); // error
+        assertEquals(
+                expectedObject.getError().get("error_description"),
+                oauthErrorNode.get("error_description").textValue()); // error description
+    }
+
+    @Test
+    void handleResponseShouldReturnForbiddenResponseWhenSessionIdIsInvalid()
+            throws JsonProcessingException {
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
@@ -664,9 +696,7 @@ class DrivingPermitHandlerTest {
         assertNotNull(oauthErrorNode);
         assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
 
-        assertEquals(
-                "oauth_error",
-                responseTreeRootNode.fieldNames().next().toString()); // Root Node Name
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
         assertEquals(
                 expectedObject.getError().get("error"),
                 oauthErrorNode.get("error").textValue()); // error

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/DocumentCheckResultItemNotFoundException.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/DocumentCheckResultItemNotFoundException.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.exception;
+
+import java.io.Serial;
+
+public class DocumentCheckResultItemNotFoundException extends Exception {
+    @Serial private static final long serialVersionUID = -7399257595290334637L;
+
+    public DocumentCheckResultItemNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/PersonIdentityDetailedNotFoundException.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/PersonIdentityDetailedNotFoundException.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.exception;
+
+import java.io.Serial;
+
+public class PersonIdentityDetailedNotFoundException extends Exception {
+    @Serial private static final long serialVersionUID = 2806354927766149300L;
+
+    public PersonIdentityDetailedNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/SessionItemNotFoundException.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/exception/SessionItemNotFoundException.java
@@ -1,0 +1,11 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.exception;
+
+import java.io.Serial;
+
+public class SessionItemNotFoundException extends Exception {
+    @Serial private static final long serialVersionUID = -2610722176794913136L;
+
+    public SessionItemNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandlerTest.java
@@ -59,7 +59,6 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
-import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DRIVING_PERMIT_CI_PREFIX;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK;
@@ -271,7 +270,7 @@ class IssueCredentialHandlerTest {
                         any(VCISSDocumentCheckAuditExtension.class));
         assertEquals(
                 ContentType.APPLICATION_JSON.getType(), response.getHeaders().get("Content-Type"));
-        assertEquals(HttpStatusCode.BAD_REQUEST, response.getStatusCode());
+        assertEquals(HttpStatusCode.FORBIDDEN, response.getStatusCode());
     }
 
     @Test
@@ -372,6 +371,129 @@ class IssueCredentialHandlerTest {
     }
 
     @Test
+    void
+            shouldReturnAServerErrorWhenPersonIdentityDetailedNotFoundExceptionOccursDuringRetrievingPersonIdentityWithSessionId()
+                    throws JsonProcessingException, SqsException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        event.withHeaders(
+                Map.of(
+                        IssueCredentialHandler.AUTHORIZATION_HEADER_KEY,
+                        accessToken.toAuthorizationHeader()));
+
+        setRequestBodyAsPlainJWT(event);
+
+        SessionItem sessionItem = new SessionItem();
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
+        when(mockPersonIdentityService.getPersonIdentityDetailed(sessionItem.getSessionId()))
+                .thenReturn(null);
+
+        APIGatewayProxyResponseEvent responseEvent = handler.handleRequest(event, context);
+
+        verify(mockSessionService).getSessionByAccessToken(accessToken);
+        verify(mockPersonIdentityService).getPersonIdentityDetailed(sessionItem.getSessionId());
+        verify(mockAuditService, never())
+                .sendAuditEvent(
+                        eq(AuditEventType.VC_ISSUED),
+                        any(AuditEventContext.class),
+                        any(VCISSDocumentCheckAuditExtension.class));
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(eq(LAMBDA_ISSUE_CREDENTIAL_FUNCTION_INIT_DURATION), anyDouble());
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR);
+        verifyNoMoreInteractions(mockEventProbe);
+        verifyNoMoreInteractions(mockAuditService);
+
+        JsonNode responseTreeRootNode = new ObjectMapper().readTree(responseEvent.getBody());
+        JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
+
+        CommonExpressOAuthError expectedObject =
+                new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR);
+
+        assertNotNull(responseEvent);
+        assertNotNull(responseTreeRootNode);
+        assertNotNull(oauthErrorNode);
+        assertEquals(OAuth2Error.SERVER_ERROR.getHTTPStatusCode(), responseEvent.getStatusCode());
+
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
+        assertEquals(
+                expectedObject.getError().get("error"),
+                oauthErrorNode.get("error").textValue()); // error
+        assertEquals(
+                expectedObject.getError().get("error_description"),
+                oauthErrorNode.get("error_description").textValue()); // error description
+    }
+
+    @Test
+    void
+            shouldReturnAServerErrorWhenDocumentCheckResultItemNotFoundExceptionOccursDuringRetrievingPersonIdentityWithSessionId()
+                    throws JsonProcessingException, SqsException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        AccessToken accessToken = new BearerAccessToken();
+        event.withHeaders(
+                Map.of(
+                        IssueCredentialHandler.AUTHORIZATION_HEADER_KEY,
+                        accessToken.toAuthorizationHeader()));
+
+        setRequestBodyAsPlainJWT(event);
+
+        SessionItem sessionItem = new SessionItem();
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(sessionItem);
+
+        PersonIdentityDetailed savedPersonIdentityDetailed =
+                PersonIdentityDetailedTestDataGenerator.generate("DVLA");
+
+        DocumentCheckResultItem savedDocumentCheckResultItem =
+                DocumentCheckTestDataGenerator.generateValidResultItem(
+                        UUID.randomUUID(), savedPersonIdentityDetailed);
+
+        PersonIdentityDetailed auditEventPersonIdentityDetailed =
+                VcIssuedAuditHelper.mapPersonIdentityDetailedAndDrivingPermitDataToAuditRestricted(
+                        savedPersonIdentityDetailed, savedDocumentCheckResultItem);
+
+        when(mockPersonIdentityService.getPersonIdentityDetailed(sessionItem.getSessionId()))
+                .thenReturn(auditEventPersonIdentityDetailed);
+        when(mockDocumentCheckResultStorageService.getDocumentCheckResult(
+                        sessionItem.getSessionId()))
+                .thenReturn(null);
+
+        APIGatewayProxyResponseEvent responseEvent = handler.handleRequest(event, context);
+
+        verify(mockSessionService).getSessionByAccessToken(accessToken);
+
+        verify(mockAuditService, never())
+                .sendAuditEvent(
+                        eq(AuditEventType.VC_ISSUED),
+                        any(AuditEventContext.class),
+                        any(VCISSDocumentCheckAuditExtension.class));
+        InOrder inOrder = inOrder(mockEventProbe);
+        inOrder.verify(mockEventProbe)
+                .counterMetric(eq(LAMBDA_ISSUE_CREDENTIAL_FUNCTION_INIT_DURATION), anyDouble());
+        inOrder.verify(mockEventProbe).counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR);
+        verifyNoMoreInteractions(mockEventProbe);
+        verifyNoMoreInteractions(mockAuditService);
+
+        JsonNode responseTreeRootNode = new ObjectMapper().readTree(responseEvent.getBody());
+        JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
+
+        CommonExpressOAuthError expectedObject =
+                new CommonExpressOAuthError(OAuth2Error.SERVER_ERROR);
+
+        assertNotNull(responseEvent);
+        assertNotNull(responseTreeRootNode);
+        assertNotNull(oauthErrorNode);
+        assertEquals(OAuth2Error.SERVER_ERROR.getHTTPStatusCode(), responseEvent.getStatusCode());
+
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
+        assertEquals(
+                expectedObject.getError().get("error"),
+                oauthErrorNode.get("error").textValue()); // error
+        assertEquals(
+                expectedObject.getError().get("error_description"),
+                oauthErrorNode.get("error_description").textValue()); // error description
+    }
+
+    @Test
     void handleResponseShouldThrowExceptionWhenSessionIdMissing() throws JsonProcessingException {
         APIGatewayProxyRequestEvent mockRequestEvent =
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
@@ -388,17 +510,14 @@ class IssueCredentialHandlerTest {
         JsonNode oauthErrorNode = responseTreeRootNode.get("oauth_error");
 
         CommonExpressOAuthError expectedObject =
-                new CommonExpressOAuthError(
-                        OAuth2Error.ACCESS_DENIED, SESSION_NOT_FOUND.getMessage());
+                new CommonExpressOAuthError(OAuth2Error.ACCESS_DENIED);
 
         assertNotNull(responseEvent);
         assertNotNull(responseTreeRootNode);
         assertNotNull(oauthErrorNode);
         assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
 
-        assertEquals(
-                "oauth_error",
-                responseTreeRootNode.fieldNames().next().toString()); // Root Node Name
+        assertEquals("oauth_error", responseTreeRootNode.fieldNames().next()); // Root Node Name
         assertEquals(
                 expectedObject.getError().get("error"),
                 oauthErrorNode.get("error").textValue()); // error

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/logging/LoggingSupport.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/logging/LoggingSupport.java
@@ -1,0 +1,17 @@
+package uk.gov.di.ipv.cri.drivingpermit.library.logging;
+
+import software.amazon.lambda.powertools.logging.LoggingUtils;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+public class LoggingSupport {
+    private static final String GOVUK_SIGNIN_JOURNEY_ID = "govuk_signin_journey_id";
+
+    @ExcludeFromGeneratedCoverageReport
+    private LoggingSupport() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+
+    public static void clearPersistentJourneyKeys() {
+        LoggingUtils.removeKey(GOVUK_SIGNIN_JOURNEY_ID);
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

clearPersistentJourneyKeys at the start of each lambda.
Add null checks on sessionId header to personInfo.
Improve null checks around lambda input headers.
Add null checks to DynamoDb returned items.
Catch known common-api exceptions to log their occurrences.
Aligned IssueCredential exception handling between Fraud, DL and Passport

### Why did it change

clearPersistentJourneyKeys to avoid using latched keys in logs prior to them being set by the session service.
SessionId header null checks for parity with the other lambdas and aid tracking of issues.
Input headers may not be present.
DynamoDB can return null objects and this is suspected to be the cause of low frequency null pointer.
The known common-api exceptions being caught and log is to aid diagnoses of null returned items prior to implementing retries.
IssueCredential exception handling alignment to aid maintainability and the errors scenarios are the same for each.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1662](https://govukverify.atlassian.net/browse/LIME-1662)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1662]: https://govukverify.atlassian.net/browse/LIME-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ