### PR TITLE
LIME-1665 Disable alarms in non-pipeline stacks to reduce alarm notification noise

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,77 +143,77 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 165
+        "line_number": 160
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 168
+        "line_number": 163
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 171
+        "line_number": 166
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 174
+        "line_number": 169
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 177
+        "line_number": 172
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 197
+        "line_number": 192
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 198
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 211
+        "line_number": 206
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 641
+        "line_number": 636
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 951
+        "line_number": 946
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 958
+        "line_number": 953
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -476,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-17T07:02:44Z"
+  "generated_at": "2025-06-04T07:51:54Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -82,6 +82,10 @@ Conditions:
   IsDeployedFromPipeline: !Equals
     - !Ref DeploymentType
     - "pipeline"
+  # Alarms only enabled in pipelines by default
+  AlarmsEnabled: !Equals
+    - !Ref DeploymentType
+    - "pipeline"
   # This is a special case fix to avoid setting this environment wide feature flag in dev.
   # As it becomes owned by the first stack using it. Remove once the feature flag is removed and feature is permanent.
   OverrideSettingOfEnvironmentWideFeatureFlag: !Equals
@@ -114,14 +118,6 @@ Conditions:
       - Fn::Equals:
           - !Ref ParameterPrefix
           - "none"
-  IsNotDevelopment: !Or
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-    - !Equals [ !Ref Environment, production ]
-  DeployAlarms: !Or
-    - Condition: IsNotDevelopment
-    - !Equals [!Ref DeployAlarmsInDev, true]
 
   CreateMockTxmaResources:
     Fn::And:
@@ -153,7 +149,6 @@ Globals:
     Runtime: java17
     AutoPublishAlias: live
     AutoPublishAliasAllProperties: true
-
     Tracing: Active
     MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref 'Environment']
     Architectures:
@@ -1379,6 +1374,7 @@ Resources:
 
   CommonAPISessionLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} - Common API Session Lambda concurrency threshold reached
       ActionsEnabled: true
@@ -1426,6 +1422,7 @@ Resources:
 
   CommonAPIAuthorizationLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} - Common API Authorization Lambda concurrency threshold reached
       ActionsEnabled: true
@@ -1449,6 +1446,7 @@ Resources:
 
   CommonAPIAccessTokenLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} - Common API AccessToken Lambda concurrency threshold reached
       ActionsEnabled: true
@@ -1498,6 +1496,7 @@ Resources:
 
   DLDrivingPermitCheckLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} - DrivingPermitCheck Lambda concurrency threshold reached
       ActionsEnabled: true
@@ -1521,6 +1520,7 @@ Resources:
 
   DLIssueCredentialLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} - IssueCredential Lambda concurrency threshold reached
       ActionsEnabled: true
@@ -1544,6 +1544,7 @@ Resources:
 
   DLLambdaErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} lambda errors
       ActionsEnabled: true
@@ -1565,6 +1566,7 @@ Resources:
 
   DLAPIGW5XXErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmDescription: !Sub Driving Licence ${Environment} API Gateway 5XX errors
       ActionsEnabled: true
@@ -1609,6 +1611,7 @@ Resources:
 
   DVLAAuthenticateTokenRequestDeniedAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment} - Driving Licence - DVLA Authenticate Token Request Denied Alarm"
       AlarmDescription: !Sub Driving Licence ${Environment} DVLA Token endpoint returned a 400/401 response to a token request (failure to authenticate)
@@ -1633,6 +1636,7 @@ Resources:
 
   CertificateExpiryAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment} - Driving Licence - Certificate expiry Alarm"
       AlarmDescription: !Sub Driving Licence ${Environment} DVA certificate is close to expiry (expires within 28 days) see certificate catalogue in confluence for expiries and certificate names
@@ -1704,7 +1708,7 @@ Resources:
 
   5XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-5XXErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
@@ -1782,7 +1786,7 @@ Resources:
 
   5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-5XXErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
@@ -1860,7 +1864,7 @@ Resources:
 
   LatencyAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-apiGWLatencyAlarm"
       AlarmDescription: !Sub "There has been increased latency on backend api-gateway. ${SupportManualURL}"
@@ -1934,7 +1938,7 @@ Resources:
 
   PublicDrivingPermitApiAccessLogGroupFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       LogGroupName: !Ref PublicDrivingPermitApiAccessLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -1947,7 +1951,7 @@ Resources:
     DependsOn:
       - "PublicDrivingPermitApiAccessLogGroupFatalErrorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PublicDrivingPermitApi-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs in Public Driving Permit API. ${SupportManualURL}"
@@ -1970,7 +1974,7 @@ Resources:
 
   PrivateDrivingPermitApiAccessLogGroupFatalErrorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       LogGroupName: !Ref PrivateDrivingPermitApiAccessLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -1983,7 +1987,7 @@ Resources:
     DependsOn:
       - "PrivateDrivingPermitApiAccessLogGroupFatalErrorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PrivateDrivingPermitApi-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs in Private Driving Permit API. ${SupportManualURL}"
@@ -2006,7 +2010,7 @@ Resources:
   ################################# Common Lambda Authorization Alarms ##############################
   Authorization5XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization5XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
@@ -2068,7 +2072,7 @@ Resources:
 
   Authorization5XXApiGwErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization5XXApiGwErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
@@ -2130,7 +2134,7 @@ Resources:
 
   Authorization4XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization4XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the Authorization endpoint. ${SupportManualURL}"
@@ -2192,7 +2196,7 @@ Resources:
 
   AuthorizationThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2231,7 +2235,7 @@ Resources:
 
   AuthorizationFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       LogGroupName: !Ref AuthorizationFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -2245,7 +2249,7 @@ Resources:
     DependsOn:
       - "AuthorizationFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2271,7 +2275,7 @@ Resources:
 
   AccessToken5XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken5XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
@@ -2333,7 +2337,7 @@ Resources:
 
   AccessToken5XXApiGwErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken5XXApiGwErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
@@ -2395,7 +2399,7 @@ Resources:
 
   AccessToken4XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken4XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the AccessToken endpoint. ${SupportManualURL}"
@@ -2457,7 +2461,7 @@ Resources:
 
   AccessTokenThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2496,7 +2500,7 @@ Resources:
 
   AccessTokenFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       LogGroupName: !Ref AccessTokenFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -2510,7 +2514,7 @@ Resources:
     DependsOn:
       - "AccessTokenFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessTokenFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2534,7 +2538,7 @@ Resources:
   ################################# Common Lambda Session Alarms ##############################
   Session5XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session5XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
@@ -2596,7 +2600,7 @@ Resources:
 
   Session5XXApiGwErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session5XXApiGwErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
@@ -2658,7 +2662,7 @@ Resources:
 
   Session4XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session4XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the Session endpoint. ${SupportManualURL}"
@@ -2720,7 +2724,7 @@ Resources:
 
   SessionThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2759,7 +2763,7 @@ Resources:
 
   SessionFunctionFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       LogGroupName: !Ref SessionFunctionLogGroup
       FilterPattern: '{ $.level = "FATAL" || $.message = "Unhandled Exception:*" }'
@@ -2773,7 +2777,7 @@ Resources:
     DependsOn:
       - "SessionFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-SessionFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -2797,7 +2801,7 @@ Resources:
   ################################# DrivingPermitChecking Alarms ##############################
   DrivingPermitChecking5XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking5XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
@@ -2859,7 +2863,7 @@ Resources:
 
   DrivingPermitChecking5XXApiGwErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking5XXApiGwErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
@@ -2921,7 +2925,7 @@ Resources:
 
   DrivingPermitChecking4XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking4XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
@@ -2983,6 +2987,7 @@ Resources:
 
   DVAThirdPartyApiErrorAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DVAThirdPartyApiErrorAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of errors on the DVA third party endpoint ${SupportManualURL}"
@@ -3027,7 +3032,7 @@ Resources:
 
   DrivingPermitCheckingThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -3065,6 +3070,7 @@ Resources:
     DependsOn:
       - "DrivingPermitCheckingFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitCheckingFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -3145,7 +3151,7 @@ Resources:
   ################################# IssueCredential Alarms ##############################
   IssueCredential5XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential5XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
@@ -3207,7 +3213,7 @@ Resources:
 
   IssueCredential5XXApiGwErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential5XXApiGwErrorCriticalAlarm"
       AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
@@ -3269,7 +3275,7 @@ Resources:
 
   IssueCredential4XXApiGwErrorAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: DeployAlarms
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential4XXApiGwErrorAlarm"
       AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the IssueCredential endpoint. ${SupportManualURL}"
@@ -3331,7 +3337,7 @@ Resources:
 
   IssueCredentialThrottleAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: AlarmsEnabled
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -3369,6 +3375,7 @@ Resources:
     DependsOn:
       - "IssueCredentialFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredentialFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
@@ -3463,6 +3470,7 @@ Resources:
     DependsOn:
       - "PersonInfoFunctionFatalErorMetricFilter"
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoFunction-FatalErrorAlarm"
       AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Disable alarms in non-pipeline stacks 

	- Remove "DeployAlarms" and replace with AlarmsEnabled 
	- Remove IsNotDevelopment as its no longer used and unsafe due to multiple configurations for dev
	- Add missing UseCanaryDeploymentAlarms condition to canary alarms

### Why did it change

To reduce alarm notification noise
To keep aligned with Fraud and Passport

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1665](https://govukverify.atlassian.net/browse/LIME-1665)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1665]: https://govukverify.atlassian.net/browse/LIME-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ