### PR TITLE
LIME-1716 - Update UI AC Tests following Branding Rework

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
@@ -282,10 +282,6 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
         Assert.assertEquals(expectedText, dvaLicenceNumberHint.getText());
     }
 
-    public void enterInValidPostCode() {
-        enterPostcode("@@@$$$**");
-    }
-
     public void enterDvaLicenceNumber(String licenceNumber) {
         DVAEnterYourDetailsExactlyPageObject dvaEnterYourDetailsExactlyPage =
                 new DVAEnterYourDetailsExactlyPageObject();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -150,24 +150,6 @@ public class DrivingLicencePageObject extends UniversalSteps {
     @FindBy(xpath = "//*[@id=\"cookies-banner-main\"]")
     public WebElement cookieBanner;
 
-    @FindBy(xpath = "/html/body/div[2]/div/p/strong")
-    public WebElement betaBanner;
-
-    @FindBy(className = "govuk-phase-banner__text")
-    public WebElement betaBannerText;
-
-    @FindBy(xpath = "//*[@id=\"cookies-banner-main\"]/div[2]/button[2]")
-    public WebElement rejectAnalysisButton;
-
-    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p")
-    public WebElement rejectanalysisActual;
-
-    @FindBy(xpath = "//*[@id=\"cookies-rejected\"]/div[1]/div/div/p/a")
-    public WebElement changeCookieButton;
-
-    @FindBy(xpath = "/html/head/link[1]")
-    public WebElement cookiePreference;
-
     @FindBy(className = "govuk-error-summary__title")
     public WebElement errorSummaryTitle;
 
@@ -514,39 +496,6 @@ public class DrivingLicencePageObject extends UniversalSteps {
     // ------------------
 
     // Should be seperate page
-
-    public void cookieBannerIsDisplayed() {
-        BrowserUtils.waitForVisibility(cookieBanner, 10);
-    }
-
-    public void betaBanner() {
-        betaBanner.isDisplayed();
-    }
-
-    public void betaBannerSentence(String expectedText) {
-        assertEquals(expectedText, betaBannerText.getText());
-        LOGGER.info("actualText = " + betaBannerText.getText());
-    }
-
-    public void rejectAnalysisCookie(String rejectAnalysis) {
-        BrowserUtils.waitForVisibility(rejectAnalysisButton, 10);
-        rejectAnalysisButton.click();
-    }
-
-    public void rejectCookieSentence(String rejectanalysisSentence) {
-        assertEquals(rejectanalysisSentence, rejectanalysisActual.getText());
-        LOGGER.info(rejectanalysisActual.getText());
-    }
-
-    public void AssertChangeCookieLink(String changeCookieLink) {
-        changeCookieButton.click();
-    }
-
-    public void AssertcookiePreferencePage() {
-
-        String changeCookiePageUrl = cookiePreference.getAttribute("href");
-        checkOkHttpResponseOnLink(changeCookiePageUrl);
-    }
 
     public void titleDVLAWithRadioBtn(String expectedText) {
         optionDVLA.isDisplayed();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
@@ -90,11 +90,6 @@ public class DVAEnterYourDetailsExactlyStepDefs extends DVAEnterYourDetailsExact
         clickOnIDoNotHaveAUKDrivingLicenceRadioButton();
     }
 
-    @When("I enter the invalid Postcode")
-    public void iEnterTheInvalidPostcode() {
-        enterInValidPostCode();
-    }
-
     @And("I clear the licence number enter the invalid Driving Licence")
     public void iClearTheLicenceNumberEnterTheInvalidDrivingLicence() {
         enterDvaLicenceNumber("1acd1113756456");

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
@@ -286,39 +286,6 @@ public class DrivingLicenceStepDefs extends DrivingLicencePageObject {
         navigateToDrivingLicenceCRIOnTestEnv();
     }
 
-    @Given("I view the Beta banner")
-    public void iViewTheBetaBanner() {
-        betaBanner();
-    }
-
-    @Then("^the beta banner reads (.*)$")
-    public void betaBannerContainsText(String expectedText) {
-        betaBannerSentence(expectedText);
-    }
-
-    @And("^I select (.*) cookie$")
-    public void selectRejectAnalysisCookie(String rejectAnalysis) {
-        cookieBannerIsDisplayed();
-        rejectAnalysisCookie(rejectAnalysis);
-    }
-
-    @Then("^I see the Reject Analysis sentence (.*)$")
-    public void
-            iSeeTheSenetenceYouVeRejectedAdditionalCookiesYouCanChangeYourCookieSettingsAtAnyTime(
-                    String rejectanalysisSentence) {
-        rejectCookieSentence(rejectanalysisSentence);
-    }
-
-    @And("^I select the (.*) link$")
-    public void iSelectTheChangeYourCookieSettingsLink(String changeCookieLink) {
-        AssertChangeCookieLink(changeCookieLink);
-    }
-
-    @Then("^I check the page to change cookie preferences opens$")
-    public void iCheckThePageToChangeCookiePreferencesOpens() {
-        AssertcookiePreferencePage();
-    }
-
     @And("^I can see OR options as (.*)$")
     public void ICanSeeTheOrDividerTextAs(String expectedText) {
         assertOrLabelText(expectedText);

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommon.feature
@@ -19,18 +19,8 @@ Feature: Driving License Test Common
     Then I can see CTA Continue
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest @build @staging @integration @smoke @stub
-  Scenario: Beta Banner Reject Analysis
-    When I view the Beta banner
-    When the beta banner reads This is a new service – your feedback (opens in new tab) will help us to improve it.
-    And I select Reject Analysis cookie
-    Then I see the Reject Analysis sentence You’ve rejected additional cookies. You can change your cookie settings at any time.
-    And  I select the ‘change your cookie settings’ link
-    Then I check the page to change cookie preferences opens
-    Then The test is complete and I close the driver
-
   @DrivingLicenceTest
-  Scenario:User selects no Driving Licence and landed in IPV Core
+  Scenario: User selects no Driving Licence and landed in IPV Core
     Given I click I do not have UK Driving License and continue
     When I am directed to the IPV Core routing page
     And I validate the URL having access denied

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Welsh/WelshLangDrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Welsh/WelshLangDrivingLicence.feature
@@ -9,56 +9,6 @@ Feature: Driving License Language Test
     And I assert the URL is valid in Welsh
 
   @Language-regression
-  Scenario: Beta Banner
-    Given I view the Beta banner
-    When the beta banner reads Mae hwn yn wasanaeth newydd – bydd eich adborth (agor mewn tab newydd) yn ein helpu i'w wella.
-    Then The test is complete and I close the driver
-
-  @Language-regression
-  Scenario Outline: DVLA Error tab title validation
-    Given I click on DVLA radio button and Parhau
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
-    Then User enters DVLA data as a <DrivingLicenceSubject>
-    And User clicks on continue
-    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
-    And The test is complete and I close the driver
-    Examples:
-      |DrivingLicenceSubject |
-      |InvalidDateOfBirth |
-
-#To be added to front end repo
-  @Language-regression
-  Scenario: DVAError tab title validation
-    Given I click on DVA radio button and Parhau
-    Then I check the page title is Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
-    When I enter the invalid Postcode
-    And User clicks on continue
-    Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – GOV.UK One Login
-    And The test is complete and I close the driver
-
-  #not existing in front end repo
-  @Language-regression
-  Scenario: DVLA Driving Licence privacy notice link to consent
-    Given I click on DVLA radio button and Parhau
-    Then I see the consent section Caniatau DVLA i wirio eich manylion trwydded yrru
-    And I see the sentence Mae DVLA angen eich caniatâd i wirio eich manylion trwydded yrru cyn y gallwch barhau. Byddant yn sicrhau nad yw eich trwydded wedi cael ei chanslo na'i hadrodd fel un sydd ar goll neu wedi'i dwyn.
-    And I see the second line I ddarganfod mwy am sut bydd eich manylion trwydded yrru yn cael eu defnyddio, gallwch ddarllen:
-    And I see privacy notice link hysbysiad preifatrwydd GOV.UK One Login (agor mewn tab newydd)
-    Then I see the DVLA privacy notice link hysbysiad preifatrwydd DVLA (agor mewn tab newydd)
-    And The test is complete and I close the driver
-
-  #not existing in front end repo
-  @Language-regression
-  Scenario: DVA Driving Licence privacy notice link to consent
-    Given I click on DVA radio button and Parhau
-    Then I see the DVA consent section Caniatau DVA i wirio eich manylion trwydded yrru
-    And I see the Consent sentence in DVA page Mae DVA angen eich caniatâd i wirio eich manylion trwydded yrru cyn y gallwch barhau. Byddant yn sicrhau nad yw eich trwydded wedi cael ei chanslo na'i hadrodd fel un sydd ar goll neu wedi'i dwyn.
-    And I see the Consent second line in DVA page I ddarganfod mwy am sut bydd eich manylion trwydded yrru yn cael eu defnyddio, gallwch ddarllen:
-    And I see privacy DVA notice link hysbysiad preifatrwydd GOV.UK One Login (agor mewn tab newydd)
-    Then I see the DVA privacy notice link hysbysiad preifatrwydd DVA (agor mewn tab newydd)
-    And The test is complete and I close the driver
-
-  @Language-regression
   Scenario Outline: Language Title validation Welsh DVLA
     Given I click on DVLA radio button and Parhau
     Then User clicks language toggle and switches to English


### PR DESCRIPTION
Beta Banner check test removed, this is covered on the FE repo already Removed other Welsh tests which are no longer required and covered under the FE Repo. Only 2 Welsh Tests remain (toggle between English and Welsh Lang) these will remain on the BE Repo Removed Elements, methods and step defs no longer required.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1716](https://govukverify.atlassian.net/browse/LIME-1716)

### Other considerations

All Tests passing locally against the @stub test tag
<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1716]: https://govukverify.atlassian.net/browse/LIME-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ