### PR TITLE
LIME-1773 | SupportManualURL correction and update from default param…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       files: .template\.yaml$
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.270'
+    rev: '3.2.456'
     hooks:
     - id: checkov
       verbose: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,42 +143,42 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 159
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 166
+        "line_number": 162
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 165
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 168
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 192
+        "line_number": 188
       },
       {
         "type": "Secret Keyword",
@@ -476,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-04T07:51:54Z"
+  "generated_at": "2025-07-28T13:08:35Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -61,10 +61,6 @@ Parameters:
     Description: "Set to the string value `true` to deploy alarms in a DEV environment"
     Type: String
     Default: false
-  SupportManualURL:
-    Description: "Link to the DL support manual"
-    Type: String
-    Default: 'https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3623583745/F2F+Support+Documentation'
   CreateMockTxmaResourcesOverride:
     Description: "Mock TXMA SQS Queue"
     Type: String
@@ -193,6 +189,10 @@ Globals:
         - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
 
 Mappings:
+  StaticVariables:
+    Urls:
+      SupportManualURL: "https://team-manual.account.gov.uk/teams/CRI-Lime-team/Supporting-CRI-Lime/"
+
   EnvironmentConfiguration:
     dev:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -290,7 +290,7 @@ Mappings:
       integration: "cron(0 10 ? 1/2 TUE#1 *)"
       production: "cron(0 10 ? 1/2 TUE#1 *)"
 
-# CANNOT be enabled (1) with SnapStart
+  # CANNOT be enabled (1) with SnapStart
   ProvisionedConcurrency:
     Environment:
       dev: 0
@@ -1713,7 +1713,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-5XXErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -1791,7 +1793,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-5XXErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the backend api-gateway. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -1869,7 +1873,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-apiGWLatencyAlarm"
-      AlarmDescription: !Sub "There has been increased latency on backend api-gateway. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been increased latency on backend api-gateway. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -1956,7 +1962,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PublicDrivingPermitApi-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs in Public Driving Permit API. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs in Public Driving Permit API. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -1992,7 +2000,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PrivateDrivingPermitApi-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs in Private Driving Permit API. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs in Private Driving Permit API. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2015,7 +2025,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2077,7 +2089,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the Authorization endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -2139,7 +2153,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Authorization4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the Authorization endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 4XX errors on the Authorization endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2206,7 +2222,9 @@ Resources:
       OKActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${CommonStackName}-AuthorizationFunction lambda throttles. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger if the ${CommonStackName}-AuthorizationFunction lambda throttles. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -2254,7 +2272,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2280,7 +2300,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2342,7 +2364,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the AccessToken endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -2404,7 +2428,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessToken4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the AccessToken endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 4XX errors on the AccessToken endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2471,7 +2497,9 @@ Resources:
       OKActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${CommonStackName}-AccessTokenFunction lambda throttles. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger if the ${CommonStackName}-AccessTokenFunction lambda throttles. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-AccessTokenFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -2519,7 +2547,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-AccessTokenFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2543,7 +2573,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2605,7 +2637,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the Session endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -2667,7 +2701,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-Session4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the Session endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 4XX errors on the Session endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2734,7 +2770,9 @@ Resources:
       OKActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${CommonStackName}-SessionFunction lambda throttles. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger if the ${CommonStackName}-SessionFunction lambda throttles. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-SessionFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -2782,7 +2820,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-SessionFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2806,7 +2846,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2868,7 +2910,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -2930,7 +2974,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitChecking4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 4XX errors on the DrivingPermitChecking endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -2992,7 +3038,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DVAThirdPartyApiErrorAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of errors on the DVA third party endpoint ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of errors on the DVA third party endpoint ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-critical-alert-topic
@@ -3042,7 +3090,9 @@ Resources:
       OKActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${DrivingPermitCheckingFunction} lambda throttles. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger if the ${DrivingPermitCheckingFunction} lambda throttles. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitCheckingFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -3075,7 +3125,9 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-DrivingPermitCheckingFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -3156,7 +3208,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -3218,7 +3272,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a significant proportion of 5XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
@@ -3280,7 +3336,9 @@ Resources:
     Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredential4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "There has been a small proportion of 4XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "There has been a small proportion of 4XX errors on the IssueCredential endpoint. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -3347,7 +3405,9 @@ Resources:
       OKActions:
         - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
       InsufficientDataActions: []
-      AlarmDescription: !Sub "Trigger if the ${IssueCredentialFunction} lambda throttles. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger if the ${IssueCredentialFunction} lambda throttles. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       AlarmName: !Sub "${AWS::StackName}-IssueCredentialFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
@@ -3380,7 +3440,9 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-IssueCredentialFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -3475,7 +3537,9 @@ Resources:
     Condition: UseCanaryDeploymentAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-PersonInfoFunction-FatalErrorAlarm"
-      AlarmDescription: !Sub "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "Trigger an alarm when Fatal Error occurs. ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [ StaticVariables, Urls, SupportManualURL ]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic


### PR DESCRIPTION
[LIME-1773] | SupportManualURL correction and update from default parameter to mapping + pre-commit checkov patch version upgrade.

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
- correct support manual URL
- change support manual URL from parameter to mapping
- a patch version update for checkov pre-commit hook 
- updates to template.yaml secret line numbers
<!-- Describe the changes in detail - the "what"-->

### Why did it change
The URL was incorrect, and changes to the default parameter would not be pulled in on stack updates.
The workaround was the change to a mapping.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1773](https://govukverify.atlassian.net/browse/LIME-1773)

### Other considerations
Evidence:

<img width="298" height="292" alt="Screenshot 2025-07-28 at 16 13 32" src="https://github.com/user-attachments/assets/50dcb73d-32c4-4fd5-9d6a-ae41a189c373" />


Alarms in dev deployment show correct URL

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1773]: https://govukverify.atlassian.net/browse/LIME-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1773]: https://govukverify.atlassian.net/browse/LIME-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ