### PR TITLE
LIME-1737 Added support for public /.well-known/jwks.json endpoint in DL

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -87,7 +87,6 @@ jobs:
             cri:deployment-source=github-actions
           parameters: |
             DeploymentType=pre-merge-integration
-            UseApiKey=" "
             ParameterPrefix=${{ secrets.PREMERGE_PARAMETER_PREFIX_STACK_NAME }}
             Environment=dev
             CommonStackName=driving-permit-common-cri-api-local

--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -86,7 +86,6 @@ jobs:
             cri:deployment-source=github-actions
           parameters: |
             DeploymentType=pre-merge-integration
-            UseApiKey=" "
             ParameterPrefix=${{ secrets.PREMERGE_PARAMETER_PREFIX_STACK_NAME }}
             Environment=dev
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": "infrastructure/lambda/public-api.yaml",
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 99
       }
     ],
     "infrastructure/lambda/template.yaml": [
@@ -199,21 +199,21 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 636
+        "line_number": 598
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 946
+        "line_number": 908
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 953
+        "line_number": 915
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -476,5 +476,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-28T13:08:35Z"
+  "generated_at": "2025-08-05T15:55:20Z"
 }

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -36,7 +36,7 @@ echo "STACK_NAME ${STACK_NAME}"
 if [ "${STACK_NAME}" != "local" ]; then
   export JOURNEY_TAG=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
 
-  PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl)
+  PARAMETERS_NAMES=(coreStubPassword coreStubUrl coreStubUsername passportCriUrl apiBaseUrl orchestratorStubUrl API_GATEWAY_ID_PUBLIC)
   tLen=${#PARAMETERS_NAMES[@]}
    for (( i=0; i<${tLen}; i++ ));
   do

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
@@ -1,11 +1,21 @@
 package gov.di_ipv_drivingpermit.pages;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.di_ipv_drivingpermit.service.ConfigurationService;
 import gov.di_ipv_drivingpermit.utilities.Driver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.support.PageFactory;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -14,6 +24,12 @@ import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.waitForUrlToContai
 import static org.junit.Assert.assertTrue;
 
 public class UniversalSteps {
+
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private final ConfigurationService configurationService =
+            new ConfigurationService(System.getenv("ENVIRONMENT"));
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -64,6 +80,91 @@ public class UniversalSteps {
         } catch (Exception e) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    private HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newBuilder().build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        return response;
+    }
+
+    public void getRequestToJwksEndpoint() throws IOException, InterruptedException {
+        String publicApiGatewayUrl = configurationService.getPublicAPIEndpoint();
+        LOGGER.info("getPublicAPIEndpoint() ==> {}", publicApiGatewayUrl);
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(publicApiGatewayUrl + "/.well-known/jwks.json"))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .GET()
+                        .build();
+        String wellKnownJWKSResponse = sendHttpRequest(request).body();
+        LOGGER.info("wellKnownJWKSResponse = {}", wellKnownJWKSResponse);
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(wellKnownJWKSResponse);
+            JsonNode keysNode = rootNode.path("keys").get(0);
+
+            // Assertions for each key-value pair
+            Assertions.assertTrue(keysNode.has("kty"), "kty field is missing");
+            Assertions.assertEquals("RSA", keysNode.path("kty").asText(), "kty value is incorrect");
+            Assertions.assertTrue(keysNode.has("n"), "n field is missing");
+            Assertions.assertTrue(keysNode.has("e"), "e field is missing");
+            Assertions.assertEquals("AQAB", keysNode.path("e").asText(), "e value is incorrect");
+            Assertions.assertTrue(keysNode.has("use"), "use field is missing");
+            Assertions.assertEquals("enc", keysNode.path("use").asText(), "use value is incorrect");
+            Assertions.assertTrue(keysNode.has("kid"), "kid field is missing");
+            Assertions.assertTrue(keysNode.has("alg"), "alg field is missing");
+            Assertions.assertEquals(
+                    "RSA_OAEP_256", keysNode.path("alg").asText(), "alg value is incorrect");
+
+        } catch (IOException e) {
+            LOGGER.error("Error parsing JSON response: {}", e.getMessage());
+            // Handle the exception appropriately, e.g., throw a custom exception or fail the test
+            Assertions.fail("Error parsing JSON response: " + e.getMessage()); // Fail the test
+        } catch (NullPointerException e) {
+            LOGGER.error("Error accessing JSON node: {}", e.getMessage());
+            Assertions.fail("Error accessing JSON node: " + e.getMessage()); // Fail the test
+        }
+    }
+
+    public void postRequestToPublicApiEndpointWithoutApiKey(String endpoint)
+            throws IOException, InterruptedException {
+        String publicApiGatewayUrl = configurationService.getPublicAPIEndpoint();
+        LOGGER.info("getPublicAPIEndpoint() ==> " + publicApiGatewayUrl);
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(URI.create(publicApiGatewayUrl + endpoint))
+                        .setHeader("Accept", "application/json")
+                        .setHeader("Content-Type", "application/json")
+                        .POST(HttpRequest.BodyPublishers.ofString(""))
+                        .build();
+        String publicAPIGatewayEndpointPostResponse = sendHttpRequest(request).body();
+        LOGGER.info(
+                "publicAPIGatewayEndpointPostResponse = " + publicAPIGatewayEndpointPostResponse);
+        try {
+            ObjectMapper objectMapper =
+                    new ObjectMapper(); // Assuming you have ObjectMapper defined elsewhere
+            JsonNode rootNode = objectMapper.readTree(publicAPIGatewayEndpointPostResponse);
+
+            // Assertion for the expected error message
+            Assertions.assertEquals(
+                    "Forbidden",
+                    rootNode.path("message").asText(),
+                    "Unexpected error message received");
+
+        } catch (IOException e) {
+            LOGGER.error("Error parsing JSON response: {}", e.getMessage());
+            Assertions.fail(
+                    "Error parsing JSON response: "
+                            + e.getMessage()); // Fail the test if parsing fails
+        } catch (NullPointerException e) {
+            LOGGER.error("Error accessing JSON node: {}", e.getMessage());
+            Assertions.fail(
+                    "Error accessing JSON node: "
+                            + e.getMessage()); // Fail the test if node is missing
         }
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
@@ -3,6 +3,9 @@ package gov.di_ipv_drivingpermit.step_definitions;
 import gov.di_ipv_drivingpermit.pages.UniversalSteps;
 import io.cucumber.java.AfterAll;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+
+import java.io.IOException;
 
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.changeLanguageTo;
 
@@ -18,6 +21,19 @@ public class UniversalStepDefs extends UniversalSteps {
     public void iAddACookieToChangeTheLanguageTo(String language) {
         String languageCode = changeLanguageTo(language);
         assertURLContains("?lng=" + languageCode);
+    }
+
+    @Given("User sends a GET request to the well-known jwks endpoint")
+    public void user_sends_a_get_request_to_well_known_jwks_end_point()
+            throws IOException, InterruptedException {
+        getRequestToJwksEndpoint();
+    }
+
+    @And(
+            "User sends a basic POST request to public (.*) endpoint without apiKey they get a forbidden error$")
+    public void user_sends_basic_post_to_public_endpoint(String endpoint)
+            throws IOException, InterruptedException {
+        postRequestToPublicApiEndpointWithoutApiKey(endpoint);
     }
 
     @AfterAll

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommonApi.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/Common/DLCommonApi.feature
@@ -1,0 +1,13 @@
+Feature: Driving License Test Common - API
+
+  @DrivingLicenceTest @build @staging @stub @uat
+  Scenario: GET request to well-known/jwks endpoint returns single public key
+    Given User sends a GET request to the well-known jwks endpoint
+
+  @DrivingLicenceTest @build @staging @stub @uat
+  Scenario Outline: Public API endpoints that are not well known cannot be accessed (issuer/token)
+    Given User sends a basic POST request to public <endpoint_name> endpoint without apiKey they get a forbidden error
+    Examples:
+      | endpoint_name     |
+      | /token            |
+      | /credential/issue |

--- a/deploy.sh
+++ b/deploy.sh
@@ -49,6 +49,5 @@ sam deploy --stack-name "$stack_name" \
   CriIdentifier=$cri_identifier \
   CreateMockTxmaResourcesOverride=true \
   ParameterPrefix="dl-cri-api-v1" \
-  UseApiKey="' '" \
   DeploymentType="not-pipeline" \
   LambdaDeploymentPreference="AllAtOnce"

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -56,7 +56,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
       security:
-        - api_key: []
+        - api_key:
+            Fn::If:
+              - IsDeployedFromPipeline
+              - [ ]
+              - Ref: AWS::NoValue
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
@@ -106,7 +110,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
       security:
-        - api_key: []
+        - api_key:
+            Fn::If:
+              - IsDeployedFromPipeline
+              - [ ]
+              - Ref: AWS::NoValue
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
@@ -118,6 +126,177 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
+
+  /.well-known/jwks.json:
+    get:
+      operationId: getWellKnownJwksJson
+      summary: Get request for the Driving Licence JWKSet
+      description: >-
+        Returns the current valid public keys used to encrypt JWTs issued by the service as a JSON Web Key Set
+      tags:
+        - Backend - Driving Licence CRI specific
+      responses:
+        "200":
+          description: >-
+            OK - key ring returned
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSFile"
+        "400":
+          description: 400 response
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+        "500":
+          description: Internal Server Error
+          headers:
+            Cache-Control:
+              schema:
+                type: "string"
+            Content-Type:
+              schema:
+                type: "string"
+            Strict-Transport-Security:
+              schema:
+                type: "string"
+            X-Content-Type-Options:
+              schema:
+                type: "string"
+            X-Frame-Options:
+              schema:
+                type: "string"
+      x-amazon-apigateway-integration:
+        httpMethod: "GET"
+        credentials:
+          Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-dl-published-keys-${Environment}/jwks.json"
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws"
+
+components:
+  schemas:
+    TokenResponse:
+      title: AccessToken
+      required:
+        - "access_token"
+        - "expires_in"
+      type: "object"
+      properties:
+        access_token:
+          type: string
+          description: The Access Token for the given token request.
+        token_type:
+          type: string
+          description: The Token Type issued.
+          example: Bearer
+        expires_in:
+          type: string
+          description: The expiry time, in seconds.
+          example: '3600'
+        refresh_token:
+          type: string
+          description: The refresh token is optional, not currently applicable.
+
+    Error:
+      title: "Error Schema"
+      type: "object"
+      properties:
+        message:
+          type: "string"
+
+    JWKSFile:
+      type: object
+      required:
+        - keys
+      additionalProperties: true
+      properties:
+        keys:
+          type: array
+          description: >-
+            The value of the `keys` parameter is an array of JWK values. By default, the order of the JWK
+            values within the array does not imply an order of preference among them, although applications of
+            JWK Sets can choose to assign a meaning to the order for their purposes, if desired.
+          items:
+            type: object
+            additionalProperties: true
+            description: >-
+              A JSON Web Key (JWK) as defined by [RFC7517](https://www.rfc-editor.org/rfc/rfc7517)
+            properties:
+              kty:
+                type: string
+                description: >-
+                  The `kty` (key type) parameter identifies the cryptographic algorithm family used with the
+                  key, such as `RSA or `EC`
+              use:
+                type: string
+                enum:
+                  - sig
+                  - enc
+                description: >-
+                  The "use" (public key use) parameter identifies the intended use of the public key.  The
+                  "use" parameter is employed to indicate whether a public key is used for encrypting data or
+                  verifying the signature on data. Valid values are `sig` (signature) and `enc` (encryption).
+              alg:
+                type: string
+                description: >-
+                  The `alg` (algorithm) parameter identifies the algorithm intended for use with the key.
+              kid:
+                type: string
+                description: >-
+                  The `kid` (key ID) parameter is used to match a specific key. This is used, for instance,
+                  to choose among a set of keys within a JWK Set during key rollover.  The structure of the
+                  `kid` value is unspecified.
+              e:
+                type: string
+                description: >-
+                  public exponent
+              n:
+                type: string
+                description: >-
+                  public modulus
+            required:
+              - kty
+
+  securitySchemes:
+    api_key:
+      type: "apiKey"
+      name: "x-api-key"
+      in: "header"
 
 x-amazon-apigateway-request-validators:
   Validate both:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -391,44 +391,6 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: './public-api.yaml'
-        components:
-          schemas:
-            TokenResponse:
-              title: AccessToken
-              required:
-                - "access_token"
-                - "expires_in"
-              type: "object"
-              properties:
-                access_token:
-                  type: string
-                  description: The Access Token for the given token request.
-                token_type:
-                  type: string
-                  description: The Token Type issued.
-                  example: Bearer
-                expires_in:
-                  type: string
-                  description: The expiry time, in seconds.
-                  example: '3600'
-                refresh_token:
-                  type: string
-                  description: The refresh token is optional, not currently applicable.
-            Error:
-              title: "Error Schema"
-              type: "object"
-              properties:
-                message:
-                  type: "string"
-          securitySchemes:
-            !If
-            - IsDeployedFromPipeline
-            -
-              api_key:
-                type: "apiKey"
-                name: "x-api-key"
-                in: "header"
-            - !Ref "AWS::NoValue"
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
@@ -1159,6 +1121,34 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}/auditEventQueueEncryptionKey
       TargetKeyId: !Ref MockAuditEventQueueEncryptionKey
+
+  JWKSBucketRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "sts:AssumeRole"
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: 2012-10-17
+      Policies:
+        - PolicyName: AccessJWKSjson
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:Get*"
+                Resource:
+                  - !Sub "arn:aws:s3:::govuk-one-login-dl-published-keys-${Environment}/jwks.json"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      Tags:
+        - Key: "key_consumer_type"
+          Value: "use"
 
   ####################################################################
   #                                                                  #


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Create a public /.well-known/jwks.json endpoint that exposes the S3 file for the Driving Licence CRI

### What changed

- Added /.well-known/jwks.json to OpenAPI spec in public-api template
- Removed global requirement for api keys and conditionally requires api keys for /token and /issueCredential based on environment
- Added test scenarios to cover a request to the well-known/jwks endpoint and Public API endpoints that are not well known cannot be accessed without an api key.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1732](https://govukverify.atlassian.net/browse/LIME-1732)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
