### PR TITLE
LIME-1738 Added Alias Based Decryption Failure alarm

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1396,6 +1396,31 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
+  CommonAPISessionLambdaAliasBasedDecryptionFailure:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmName: !Sub ${AWS::StackName}-${Environment} - Driving licence - Session lambda alias-based decryption failure
+      AlarmDescription: !Sub Driving licence ${Environment} - Common API Session Lambda all aliases unavailable for decryption
+      ActionsEnabled: true
+      AlarmActions:
+        - !If [ IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic ]
+      OKActions:
+        - !If [ IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic ]
+      InsufficientDataActions: [ ]
+      MetricName: all_aliases_unavailable_for_decryption
+      Namespace: !Sub "${CriIdentifier}"
+      Statistic: Sum
+      Dimensions:
+        - Name: Service
+          Value: !Sub "${CriIdentifier}-session"
+      Period: 60
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
   CommonAPISessionLambdaFailedToVerifyJWTAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: AlarmsEnabled


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

### What changed

Changes made as part of the key rotation initiative in Driving Licence. 

Implemented alarm that alerts when no key alias available to the CRI matches the encryption key used to create the encrypted payload it received from the client (Core/Core Stub).

Uses all_aliases_unavailable_for_decryption metric from the common session lambda.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1738](https://govukverify.atlassian.net/browse/LIME-1738)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1738]: https://govukverify.atlassian.net/browse/LIME-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ