### PR TITLE
LIME-1815: Update Dynatrace OneAgent Layer version to v1_311_51_20250…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -176,44 +176,37 @@
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
-        "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
-        "is_verified": false,
-        "line_number": 186
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 196
+        "line_number": 195
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 203
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 600
+        "line_number": 599
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 915
+        "line_number": 914
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 922
+        "line_number": 921
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -476,5 +469,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-13T12:35:29Z"
+  "generated_at": "2025-08-15T11:42:28Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -182,9 +182,8 @@ Globals:
         ENVIRONMENT: !Ref Environment
         PARAMETER_PREFIX: !If [UseParameterPrefix, !Ref ParameterPrefix , !Ref AWS::StackName]
     Layers:
-      - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # or NODEJS_LAYER or PYTHON_LAYER
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+      # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
+      - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
 
 Mappings:
   StaticVariables:
@@ -3212,8 +3211,6 @@ Resources:
       AlarmDescription: !Sub "DrivingPermitChecking Lambda error."
       MetricName: Errors
       Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-DrivingPermitCheckingFunction:live"
         - Name: FunctionName
           Value: !Ref DrivingPermitCheckingFunction
         - Name: ExecutedVersion
@@ -3527,8 +3524,6 @@ Resources:
       AlarmDescription: !Sub "IssueCredential Lambda error."
       MetricName: Errors
       Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
         - Name: FunctionName
           Value: !Ref IssueCredentialFunction
         - Name: ExecutedVersion
@@ -3624,8 +3619,6 @@ Resources:
       AlarmDescription: !Sub "IssueCredential Lambda error."
       MetricName: Errors
       Dimensions:
-        - Name: Resource
-          Value: !Sub "${AWS::StackName}-PersonInfoFunction:live"
         - Name: FunctionName
           Value: !Ref PersonInfoFunction
         - Name: ExecutedVersion


### PR DESCRIPTION
### What changed

Change Dynatrace OneAgent Layer arn to a version based path for Driving License API.

### Why did it change

Need to update Dynatrace OneAgent Layer to v1_311_51_20250331-143707.

### Issue tracking

- [LIME-1815](https://govukverify.atlassian.net/browse/LIME-1815)


[LIME-1815]: https://govukverify.atlassian.net/browse/LIME-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ