### PR TITLE
LIME-1839 - Update 'alg' validation on well-known/jwks endpoint test

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
@@ -118,7 +118,7 @@ public class UniversalSteps {
             Assertions.assertTrue(keysNode.has("kid"), "kid field is missing");
             Assertions.assertTrue(keysNode.has("alg"), "alg field is missing");
             Assertions.assertEquals(
-                    "RSA_OAEP_256", keysNode.path("alg").asText(), "alg value is incorrect");
+                    "RSA-OAEP-256", keysNode.path("alg").asText(), "alg value is incorrect");
 
         } catch (IOException e) {
             LOGGER.error("Error parsing JSON response: {}", e.getMessage());


### PR DESCRIPTION
Update the validation of the ‘alg’ returned in the response

from:
RSA_OAEP_256

to:

RSA-OAEP-256

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1839](https://govukverify.atlassian.net/browse/LIME-1839)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
