### PR TITLE
Revert "LIME-1821 Disable alias based decryption alarm to allow initial key rotation in prod"

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1397,11 +1397,11 @@ Resources:
 
   CommonAPISessionLambdaAliasBasedDecryptionFailure:
     Type: AWS::CloudWatch::Alarm
-#    Condition: AlarmsEnabled
+    Condition: AlarmsEnabled
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment} - Driving licence - Session lambda alias-based decryption failure
       AlarmDescription: !Sub Driving licence ${Environment} - Common API Session Lambda all aliases unavailable for decryption
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !If [ IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic ]
       OKActions:


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-dl-api#593

- Alias based decryption alarm was disabled ahead of key rotation in DL prod which would trigger this alarm. Now re-enabling alarm as key rotation has been completed.