### PR TITLE
LIME-1845: Remove manual trigger for package for build github actions pipeline

### DIFF
--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: # deploy manually
 
 jobs:
   deploy:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Removing manual github actions trigger for a deploy to build.


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Could erroneously deploy a branch to build which could propagate up to prod.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1845](https://govukverify.atlassian.net/browse/LIME-1845)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1845]: https://govukverify.atlassian.net/browse/LIME-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ