### PR TITLE
LIME-1855: Upping the Authorization4XXApiGwAlarm threshold to reduce noise in alerting channels. Threshold to be reviewed as part of wider alarm refactoring work

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -2198,14 +2198,14 @@ Resources:
       Dimensions: [ ]
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
-      Threshold: 1
+      Threshold: 15
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
       Metrics:
         - Id: errorThreshold
           Label: errorThreshold
           ReturnData: true
-          Expression: IF(invocations<2 || error<2,0,errorPercentage)
+          Expression: IF(invocations<10,0,errorPercentage)
         - Id: invocations
           ReturnData: false
           MetricStat:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
Upped the threshold for the Authorisation 4XX API GW alarm. 

The old threshold was checking for 1% or more errors, mitigations for low traffic was set to <2 invocations.

The threshold has now been upped to 15% (based on data coming into the alerting channels), and now <10 invocations will be ignored.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
This should hopefully reduce noise in our alerting channels, making them more readable so we don't miss other alarms.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1855](https://govukverify.atlassian.net/browse/LIME-1855)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1855]: https://govukverify.atlassian.net/browse/LIME-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ