### PR TITLE
LIME-1889 Revert aws powertools version to 1.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-	aws_powertools_version = "1.20.1"
+	aws_powertools_version = "1.18.0"
 	dependencyVersions = [
 
 		cri_common_lib_version             : "6.6.0",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

aws powertools version from 1.20.1 to 1.18.0

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1889](https://govukverify.atlassian.net/browse/LIME-1889)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1889]: https://govukverify.atlassian.net/browse/LIME-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ