### PR TITLE
LIME-1904 Redirect cert expiry alarm away from di-2nd-line

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1677,9 +1677,9 @@ Resources:
       AlarmDescription: !Sub Driving Licence ${Environment} DVA certificate is close to expiry (expires within 28 days) see certificate catalogue in confluence for expiries and certificate names
       ActionsEnabled: true
       AlarmActions:
-        - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
+        - !ImportValue platform-alarm-critical-alert-topic
       OKActions:
-        - !If [IsProdEnvironment, !Ref AlarmTopicDL, !ImportValue platform-alarm-critical-alert-topic]
+        - !ImportValue platform-alarm-critical-alert-topic
       InsufficientDataActions: [ ]
       MetricName: dva_cert_expiry_metric
       Namespace: !Sub "${CriIdentifier}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Directed the prod cert expiry alarm away from di-2nd-line channel as this has been firing daily and producing pager duty notifications. Work to rotate the certificates is in progress under - [LIME-1827](https://govukverify.atlassian.net/browse/LIME-1827)

Once the certs are rotated, consideration will be given to reverting this change or leaving as is.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1904](https://govukverify.atlassian.net/browse/LIME-1904)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1827]: https://govukverify.atlassian.net/browse/LIME-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1904]: https://govukverify.atlassian.net/browse/LIME-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ