### PR TITLE
LIME-1226 - Updated DVA Tests with wait before checking error validation message

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -2,6 +2,8 @@ package gov.di_ipv_drivingpermit.step_definitions;
 
 import gov.di_ipv_drivingpermit.pages.DVAEnterYourDetailsExactlyPageObject;
 import gov.di_ipv_drivingpermit.pages.DrivingLicencePageObject;
+import gov.di_ipv_drivingpermit.utilities.BrowserUtils;
+import gov.di_ipv_drivingpermit.utilities.Driver;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -13,6 +15,12 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     @When("User clicks on continue")
     public void user_clicks_on_continue() {
         continuebutton.click();
+    }
+
+    @When("User clicks on continue and waits for page reload")
+    public void user_clicks_on_continue_and_waits_for_page_reload() {
+        continuebutton.click();
+        BrowserUtils.waitForStaleElement(Driver.get(), continuebutton);
     }
 
     @When("User clicks the DVA consent checkbox")

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -247,7 +247,7 @@ Feature: DVA Driving Licence Test
   Scenario Outline: DVA - User attempts journey with invalid details and clicks on prove another way and generates a VC
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     And User re-enters DVA license number as <InvalidLicenceNumber>
-    When User clicks on continue
+    When User clicks on continue and waits for page reload
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     When User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
@@ -262,7 +262,7 @@ Feature: DVA Driving Licence Test
   Scenario Outline: DVA - User attempts journey with consent checkbox unselected and returns error
     Given User enters DVA data as a <DrivingLicenceSubject>
     And DVA consent checkbox is unselected
-    When User clicks on continue
+    When User clicks on continue and waits for page reload
     When I can see an error box highlighted red
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     Then User can see the DVA consent error in summary as You must give your consent to continue


### PR DESCRIPTION





<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Following Scenarios Updated:

Scenario Outline: DVA - User attempts journey with consent checkbox unselected and returns error

Scenario Outline: DVA - User attempts journey with invalid details and clicks on prove another way and generates a VC

Updated the 'User clicks on continue button' to be 'User clicks on continue and waits for page reload'

added waitForStaleElement after the button click to ensure the page has fully reloaded before the next step validates.
### Why did it change

 This ensure the continue button is fully unloaded from the DOM before the validation. Indicating the page has therefore reloaded.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-1226](https://govukverify.atlassian.net/browse/LIME-1226)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->

<img width="295" height="79" alt="image" src="https://github.com/user-attachments/assets/1695d58c-da4e-47a4-b3c1-dbb9bb54c0a0" />


[LIME-2126]: https://govukverify.atlassian.net/browse/LIME-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIME-1226]: https://govukverify.atlassian.net/browse/LIME-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ