### PR TITLE
LIME-2112 Switch jfrog to mavenCentral

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -6,9 +6,7 @@ plugins {
 defaultTasks 'clean', 'build'
 
 repositories {
-	maven {
-		url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-	}
+	mavenCentral()
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,7 @@ plugins {
 defaultTasks 'clean', 'spotlessApply', 'build'
 
 repositories {
-	maven {
-		url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-	}
+	mavenCentral()
 }
 
 ext {
@@ -194,9 +192,7 @@ subprojects {
 	}
 
 	repositories {
-		maven {
-			url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
-		}
+		mavenCentral()
 		//flatDir {
 		//	dirs '<Location of your projects absolute path>/di-ipv-cri-lib/build/libs'
 		//}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Switched from 
` maven {
      url = 'https://gds.jfrog.io/artifactory/di-allowed-repos'
  }`
  to 
  `mavenCentral()`

### Why did it change

The JFrog Artifactory service will be spun down (currently planned for end of April 2026) 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2112](https://govukverify.atlassian.net/browse/LIME-2112)



[LIME-2112]: https://govukverify.atlassian.net/browse/LIME-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ