### PR TITLE
LIME-2126 - Removed Gson dependency from repo

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -84,7 +84,6 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-params",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}",
 			"org.mockito:mockito-core:${dependencyVersions.mockito_version}",
-			"com.google.code.gson:gson:${dependencyVersions.gson_version}",
 			"org.json:json:20240303"
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,6 @@ ext {
 		// Jackson Addons/ needs to track the aws sdk version of jackson
 		jackson_version                    : "2.21.1",
 
-		// GSON used in DCS/DVA pathway remove with DCS removal rework to jackson
-		gson_version                       : "2.8.9",
-
 		// Powertools Aspect API (Handers only)
 		aspectjrt_version                  : "1.9.25.1",
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Confirm this dependency is not being used anywhere 
Updated acceptance tests build.gradle
Update main build.gradle

### Why did it change

To remove the no longer required dependency 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2126](https://govukverify.atlassian.net/browse/LIME-2126)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2126]: https://govukverify.atlassian.net/browse/LIME-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ