### PR TITLE
LIME-2034 Resolve unsafe API_KEY handling in pre-merge test step

### DIFF
--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -157,15 +157,15 @@ jobs:
         run: |
           echo "🤞 now run integration tests..."
           STACK_NAME=${{ needs.deploy.outputs.stack-name }}
-          API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateDrivingPermitApiGatewayId").OutputValue')
-          API_GATEWAY_ID_PUBLIC=$(aws cloudformation describe-stacks --stack-name $STACK_NAME | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PublicDrivingPermitApiGatewayId").OutputValue')
-          export API_GATEWAY_ID_PRIVATE=$API_GATEWAY_ID_PRIVATE
-          export API_GATEWAY_ID_PUBLIC=$API_GATEWAY_ID_PUBLIC
-          export API_GATEWAY_KEY=${{ secrets.API_KEY_DEV }}
+          API_GATEWAY_ID_PRIVATE=$(aws cloudformation describe-stacks --stack-name "${STACK_NAME}" | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PrivateDrivingPermitApiGatewayId").OutputValue')
+          API_GATEWAY_ID_PUBLIC=$(aws cloudformation describe-stacks --stack-name "${STACK_NAME}" | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "PublicDrivingPermitApiGatewayId").OutputValue')
+          export API_GATEWAY_ID_PRIVATE="${API_GATEWAY_ID_PRIVATE}"
+          export API_GATEWAY_ID_PUBLIC="${API_GATEWAY_ID_PUBLIC}"
+          export API_GATEWAY_KEY="${APIGW_API_KEY}"
           AC_TEST_ONLY=true ./gradlew acceptance-tests:cucumber -P tags=@pre-merge
 
       - name: Delete pre-merge test stack
         if: always()
         run: |
           STACK_NAME=${{ needs.deploy.outputs.stack-name }}
-          aws cloudformation delete-stack --region eu-west-2 --stack-name $STACK_NAME
+          aws cloudformation delete-stack --region eu-west-2 --stack-name "${STACK_NAME}"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Resolve unsafe API_KEY handling in pre-merge test step

### Why did it change

Flagged in Sonar - https://sonarcloud.io/project/security_hotspots?id=ipv-cri-dl-api

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2034](https://govukverify.atlassian.net/browse/LIME-2034)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2034]: https://govukverify.atlassian.net/browse/LIME-2034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ