### PR TITLE
LIME-2170 - Added ObjectMapperFactory utility

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -30,8 +30,7 @@ dependencies {
 			platform(libs.junit.platform.bom),
 			libs.bundles.jackson,
 			libs.bundles.unit.testing,
-			libs.aws.cdk.lib,
-			"org.json:json:20250517" // Migration to jackson only in progress - DO not use org.json in new code
+			libs.aws.cdk.lib
 
 	testImplementation libs.actest.rest.assured,
 			libs.actest.cucumber.junit,

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -4,16 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nimbusds.jwt.SignedJWT;
 import gov.di_ipv_drivingpermit.model.AuthorisationResponse;
 import gov.di_ipv_drivingpermit.model.DocumentCheckResponse;
 import gov.di_ipv_drivingpermit.model.DrivingPermitForm;
 import gov.di_ipv_drivingpermit.service.ConfigurationService;
+import gov.di_ipv_drivingpermit.utilities.ObjectMapperFactory;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,8 +66,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
 
     private static Boolean retry;
     private static String drivingLicenceCheckResponse;
-    private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().registerModules(new JavaTimeModule());
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.MAPPER;
 
     private final ConfigurationService configurationService =
             new ConfigurationService(System.getenv("ENVIRONMENT"));
@@ -180,26 +178,24 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
             String drivingPermitIssueDate,
             String drivingPermitIssuedBy,
             String drivingPermitFullAddress) {
-        JSONObject jsonObject = new JSONObject(claimsJson);
-        JSONObject drivingPermitEntry = new JSONObject();
-
-        drivingPermitEntry.put("personalNumber", drivingPermitPersonalNumber);
-        drivingPermitEntry.put("expiryDate", drivingPermitExpiryDate);
-        drivingPermitEntry.put("issueDate", drivingPermitIssueDate);
-        drivingPermitEntry.put("issuedBy", drivingPermitIssuedBy);
-        drivingPermitEntry.put("fullAddress", drivingPermitFullAddress);
-
-        JSONArray drivingPermitArray = new JSONArray();
-        drivingPermitArray.put(drivingPermitEntry);
-
-        JSONObject sharedClaims = jsonObject.getJSONObject("shared_claims");
-
-        sharedClaims.remove("address");
-
-        sharedClaims.put("drivingPermit", drivingPermitArray);
-        jsonObject.put("context", "check_details");
-
-        return jsonObject.toString();
+        try {
+            ObjectNode jsonObject = (ObjectNode) OBJECT_MAPPER.readTree(claimsJson);
+            ObjectNode drivingPermitEntry = OBJECT_MAPPER.createObjectNode();
+            drivingPermitEntry.put("personalNumber", drivingPermitPersonalNumber);
+            drivingPermitEntry.put("expiryDate", drivingPermitExpiryDate);
+            drivingPermitEntry.put("issueDate", drivingPermitIssueDate);
+            drivingPermitEntry.put("issuedBy", drivingPermitIssuedBy);
+            drivingPermitEntry.put("fullAddress", drivingPermitFullAddress);
+            ArrayNode drivingPermitArray = OBJECT_MAPPER.createArrayNode();
+            drivingPermitArray.add(drivingPermitEntry);
+            ObjectNode sharedClaims = (ObjectNode) jsonObject.get("shared_claims");
+            sharedClaims.remove("address");
+            sharedClaims.set("drivingPermit", drivingPermitArray);
+            jsonObject.put("context", "check_details");
+            return jsonObject.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build DVA driving permit JSON", e);
+        }
     }
 
     private String insertDrivingPermitDVLA(
@@ -210,24 +206,25 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
             String drivingPermitIssueNumber,
             String drivingPermitIssuedBy,
             String drivingPermitFullAddress) {
-        JSONObject jsonObject = new JSONObject(claimsJson);
-        JSONObject drivingPermitEntry = new JSONObject();
-
-        drivingPermitEntry.put("personalNumber", drivingPermitPersonalNumber);
-        drivingPermitEntry.put("expiryDate", drivingPermitExpiryDate);
-        drivingPermitEntry.put("issueDate", drivingPermitIssueDate);
-        drivingPermitEntry.put("issueNumber", drivingPermitIssueNumber);
-        drivingPermitEntry.put("issuedBy", drivingPermitIssuedBy);
-        drivingPermitEntry.put("fullAddress", drivingPermitFullAddress);
-
-        JSONArray drivingPermitArray = new JSONArray();
-        drivingPermitArray.put(drivingPermitEntry);
-        JSONObject sharedClaims = jsonObject.getJSONObject("shared_claims");
-        sharedClaims.remove("address");
-        sharedClaims.put("drivingPermit", drivingPermitArray);
-        jsonObject.put("context", "check_details");
-
-        return jsonObject.toString();
+        try {
+            ObjectNode jsonObject = (ObjectNode) OBJECT_MAPPER.readTree(claimsJson);
+            ObjectNode drivingPermitEntry = OBJECT_MAPPER.createObjectNode();
+            drivingPermitEntry.put("personalNumber", drivingPermitPersonalNumber);
+            drivingPermitEntry.put("expiryDate", drivingPermitExpiryDate);
+            drivingPermitEntry.put("issueDate", drivingPermitIssueDate);
+            drivingPermitEntry.put("issueNumber", drivingPermitIssueNumber);
+            drivingPermitEntry.put("issuedBy", drivingPermitIssuedBy);
+            drivingPermitEntry.put("fullAddress", drivingPermitFullAddress);
+            ArrayNode drivingPermitArray = OBJECT_MAPPER.createArrayNode();
+            drivingPermitArray.add(drivingPermitEntry);
+            ObjectNode sharedClaims = (ObjectNode) jsonObject.get("shared_claims");
+            sharedClaims.remove("address");
+            sharedClaims.set("drivingPermit", drivingPermitArray);
+            jsonObject.put("context", "check_details");
+            return jsonObject.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build DVLA driving permit JSON", e);
+        }
     }
 
     public void dlUserIdentityAsJwtString(String criId, Integer rowNumber)
@@ -613,9 +610,9 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         vcBody = signedJWT.getJWTClaimsSet().toString();
         LOGGER.info("VC Body = {}", vcBody);
 
-        JSONObject jsonHeader;
+        JsonNode jsonHeader;
         try {
-            jsonHeader = new JSONObject(vcHeader);
+            jsonHeader = OBJECT_MAPPER.readTree(vcHeader);
         } catch (Exception e) {
             LOGGER.error("Failed to parse VC Header as JSON", e);
             throw new AssertionError("Failed to parse VC Header as JSON", e);
@@ -628,12 +625,12 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
         Assert.assertEquals(
                 "The 'typ' field does not have the expected value",
                 "JWT",
-                jsonHeader.getString("typ"));
+                jsonHeader.get("typ").asText());
         Assert.assertEquals(
                 "The 'alg' field does not have the expected value",
                 "ES256",
-                jsonHeader.getString("alg"));
-        String kid = jsonHeader.getString("kid");
+                jsonHeader.get("alg").asText());
+        String kid = jsonHeader.get("kid").asText();
         Assert.assertTrue(
                 "The 'kid' field does not start with the expected prefix",
                 kid.startsWith(KID_PREFIX));

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/UniversalSteps.java
@@ -3,10 +3,9 @@ package gov.di_ipv_drivingpermit.pages;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.di_ipv_drivingpermit.service.ConfigurationService;
 import gov.di_ipv_drivingpermit.utilities.Driver;
-import org.json.JSONObject;
+import gov.di_ipv_drivingpermit.utilities.ObjectMapperFactory;
 import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.support.PageFactory;
 import org.slf4j.Logger;
@@ -25,8 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 public class UniversalSteps {
 
-    private static final ObjectMapper OBJECT_MAPPER =
-            new ObjectMapper().registerModule(new JavaTimeModule());
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.MAPPER;
 
     private final ConfigurationService configurationService =
             new ConfigurationService(System.getenv("ENVIRONMENT"));
@@ -71,8 +69,7 @@ public class UniversalSteps {
         String filePath = "src/test/resources/Data/" + fileName + ".json";
         try {
             String content = new String(Files.readAllBytes(Paths.get(filePath)));
-            JSONObject jsonObject = new JSONObject(content);
-            return jsonObject.toString();
+            return OBJECT_MAPPER.readTree(content).toString();
         } catch (Exception e) {
             e.printStackTrace();
             return null;

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/ObjectMapperFactory.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/ObjectMapperFactory.java
@@ -1,0 +1,11 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ObjectMapperFactory {
+    public static final ObjectMapper MAPPER =
+            new ObjectMapper().registerModule(new JavaTimeModule());
+
+    private ObjectMapperFactory() {}
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Added ObjectMapperFactory utility in the utilities file Refactored UniversalSepts and DrivingLicenceAPIPage, removed import org.json.JSONObject and replaced with shared object mapper

### Why did it change

To improve maintainability and align with Fraud BE Config

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2170](https://govukverify.atlassian.net/browse/LIME-2170)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
<img width="304" height="85" alt="image" src="https://github.com/user-attachments/assets/5dd36f82-f71f-4273-8f56-61d8c78185c6" />


[LIME-2170]: https://govukverify.atlassian.net/browse/LIME-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ