### PR TITLE
LIME-2104 - Update Infra Test with QualityGateStackTest Tag

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/infra/CertificateTemplateTest.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/infra/CertificateTemplateTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("InfraTest")
+@Tag("QualityGateStackTest")
 @DisplayName("Certificate CloudFormation Template Assertions")
 class CertificateTemplateTest {
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/infra/LambdaTemplateTest.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/infra/LambdaTemplateTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @Tag("InfraTest")
+@Tag("QualityGateStackTest")
 @DisplayName("Lambda CloudFormation Template Assertions")
 class LambdaTemplateTest {
 


### PR DESCRIPTION
The LambdaTemplateTest and CertificateTemplateTest files has been updated and the @QualityGateStackTest has been included along side the "InfraTest" Tag

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Added @QualityGateStackTest tag to the LambdaTemplateTest and CertificateTemplateTest files

### Why did it change

To align with the correct Quality Gate Tags

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2104](https://govukverify.atlassian.net/browse/LIME-2104)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2104]: https://govukverify.atlassian.net/browse/LIME-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ