### PR TITLE
BAU: Updating actions running on node 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,7 @@ updates:
     commit-message:
       prefix: BAU
     groups:
-      pre-commit-hooks:
+      docker:
         patterns:
           - "*"
 
@@ -64,13 +64,17 @@ updates:
       interval: weekly
       day: monday
       time: "03:00"
+    ignore:
+      - dependency-name: "gradle/actions"
+        # setup-gradle v6 contains updates to terms which we need to understand and review
+        update-types: ["version-update:semver-major"]
     target-branch: main
     labels:
       - dependabot
     commit-message:
       prefix: BAU
     groups:
-      pre-commit-hooks:
+      actions:
         patterns:
           - "*"
 

--- a/.github/workflows/delete-preview-stacks.yml
+++ b/.github/workflows/delete-preview-stacks.yml
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b0015c58dd0e19e1572fda59dda4184df387d1e
+        uses: govuk-one-login/github-actions/sam/delete-stacks@2518d831abb4ec03fa3125619507f932966f2833
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}

--- a/.github/workflows/delete-stale-log-groups.yml
+++ b/.github/workflows/delete-stale-log-groups.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: govuk-one-login/github-actions/sam/delete-stale-log-groups@3b0015c58dd0e19e1572fda59dda4184df387d1e
+      - uses: govuk-one-login/github-actions/sam/delete-stale-log-groups@8d9b70ea03249a138db2b04c02071d7826cb00d9
         with:
           aws-role-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
           cutoff-days: "30"

--- a/.github/workflows/post-merge-deploy-acm-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-acm-to-dev.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -47,7 +47,7 @@ jobs:
           sam build -t infrastructure/certificate/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.DEV_DL_ACM_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -35,7 +35,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -92,7 +92,7 @@ jobs:
           sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"

--- a/.github/workflows/post-merge-package-acm-for-build.yml
+++ b/.github/workflows/post-merge-package-acm-for-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -43,7 +43,7 @@ jobs:
           sam build -t infrastructure/certificate/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.BUILD_DL_ACM_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -34,7 +34,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"
@@ -95,7 +95,7 @@ jobs:
           sam build -s "${GITHUB_WORKSPACE}" -t infrastructure/lambda/template.yaml -b out
 
       - name: Deploy SAM app
-        uses: govuk-one-login/devplatform-upload-action@b7bc01ed6e0b61d54f42e7f3d12dd3fdbb0f172a # v3.13.0
+        uses: govuk-one-login/devplatform-upload-action@245bad4dc21702a5e665f1ca615108f6e70546d2 # v4.0.0
         with:
           artifact-bucket-name: "${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.SIGNING_PROFILE_NAME }}"

--- a/.github/workflows/post-merge-sonar-scan.yml
+++ b/.github/workflows/post-merge-sonar-scan.yml
@@ -30,7 +30,7 @@ jobs:
           gradle-version: wrapper
           cache-overwrite-existing: true
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/

--- a/.github/workflows/run-infra-tests.yml
+++ b/.github/workflows/run-infra-tests.yml
@@ -43,7 +43,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/

--- a/.github/workflows/run-java-build-check.yml
+++ b/.github/workflows/run-java-build-check.yml
@@ -37,7 +37,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/

--- a/.github/workflows/run-java-style-check.yml
+++ b/.github/workflows/run-java-style-check.yml
@@ -37,7 +37,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -41,7 +41,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/

--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -117,13 +117,13 @@ jobs:
           distribution: corretto
           cache: gradle
 
-      - uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+      - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: wrapper
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/
@@ -134,7 +134,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Setup SAM
-        uses: aws-actions/setup-sam@d78e1a4a9656d3b223e59b80676a797f20093133 # v2
+        uses: aws-actions/setup-sam@89ddb14d60e682855e3fea4be85b3c56485de310 # v3
         with:
           use-installer: true
           version: "1.157.1"

--- a/.github/workflows/run-sonar-scan.yml
+++ b/.github/workflows/run-sonar-scan.yml
@@ -30,7 +30,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
 
       - name: Cache Unit Test Reports
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/
@@ -69,7 +69,7 @@ jobs:
           retention-days: 5
 
       - name: Cache Unit Test Reports
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/smoke-test-build.yml
+++ b/.github/workflows/smoke-test-build.yml
@@ -37,7 +37,7 @@ jobs:
           cache-overwrite-existing: true
 
       - name: Build Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .gradle/


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
Updating actions running on node 20

Also some small dependabot updates:
- fix groupings
- ignore setup gradle v6 updates due to changes in terms of use that need review
  - see https://blog.gradle.org/github-actions-for-gradle-v6

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Actions are forced to run on node 24 from 02/06, so its worth updating them where we can to avoid unusual or unexpected behaviour.
There was also naming mistakes from the last PR for dependabot config groupings.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
BAU

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
