### PR TITLE
LIME-2213: Update cri_common_lib to 9.0.1, limeade to 1.2.2, and open telemetry_bom_alpha to 2.28.1-alpha and remove deprecated feature flags.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,91 +143,91 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 157
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 165
+        "line_number": 160
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 194
+        "line_number": 189
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 206
+        "line_number": 201
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "db1dd8619cb44b99746e1850025b9593d65c0813",
         "is_verified": false,
-        "line_number": 271
+        "line_number": 250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "a99e55f827cf1ad50ce9d8894d85adde49fe20d4",
         "is_verified": false,
-        "line_number": 273
+        "line_number": 252
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "db83b7d0f508b36e123b1d1788053bdc9ce3aa0a",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 254
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 660
+        "line_number": 629
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 1006
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 1013
+        "line_number": 980
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -254,14 +254,14 @@
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "41c5ebe18c2f4a118ee2798dca00c8ca2f981149",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 146
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java",
         "hashed_secret": "3e4372459809fa2f4f46af84291360a04ead6573",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 147
       }
     ],
     "lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/fixtures/TestFixtures.java": [
@@ -478,5 +478,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T13:55:04Z"
+  "generated_at": "2026-06-08T14:12:32Z"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ post_compile_weaving = "9.2.0"
 aws_sdk = "2.42.34"
 aws_lambda_events = "3.16.0"
 aws_lambda_core = "1.4.0" # https://github.com/aws/aws-lambda-java-libs
-cri_common_lib = "8.3.3"
-limeade = "1.1.1"
+cri_common_lib = "9.0.1"
+limeade = "1.2.2"
 nimbusds_oauth = "11.29.2"
 aspect_jrt = "1.9.25.1"
 aws_powertools = "2.10.0"
@@ -21,7 +21,7 @@ apache_httpcomponents_httpcore = "4.4.16"
 apache_httpcomponents_httpclient = "4.5.14"
 
 # Lambdas OpenTel
-opentelemetry_bom_alpha = "2.20.1-alpha"
+opentelemetry_bom_alpha = "2.28.1-alpha"
 
 # DVA ACM
 bouncycastle_bcpkix_version = "1.84"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -78,11 +78,6 @@ Conditions:
   AlarmsEnabled: !Equals
     - !Ref DeploymentType
     - "pipeline"
-  # This is a special case fix to avoid setting this environment wide feature flag in dev.
-  # As it becomes owned by the first stack using it. Remove once the feature flag is removed and feature is permanent.
-  OverrideSettingOfEnvironmentWideFeatureFlag: !Equals
-    - !Ref Environment
-    - dev
   UsingCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -222,22 +217,6 @@ Mappings:
       integration: "6"
       production: "6"
 
-  VcExpiryRemoved:
-    Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "true"
-      production: "true"
-
-  VcContainsUniqueIdMapping:
-    Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "true"
-      production: "true"
-
   JwtTtlUnitMapping:
     Environment:
       dev: MONTHS
@@ -344,28 +323,18 @@ Mappings:
 
   FeatureFlagMapping:
     dev:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "true"
       hasCA: "false"
     build:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
       hasCA: "false"
     staging:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
       hasCA: "true"
     integration:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
       hasCA: "false"
     production:
-      VcExpiryRemoved: "true"
-      VcContainsUniqueIdMapping: "true"
       IncludeKidInVc: "false"
       hasCA: "true"
 
@@ -793,8 +762,6 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
-          ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcExpiryRemoved ]
-          ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID: !FindInMap [ FeatureFlagMapping, !Ref Environment, VcContainsUniqueIdMapping ]
           INCLUDE_VC_KID: !FindInMap [ FeatureFlagMapping, !Ref Environment, IncludeKidInVc ]
           SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
           VERIFIABLE_CREDENTIAL_ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"
@@ -1512,25 +1479,6 @@ Resources:
   # Parameters                                                       #
   #                                                                  #
   ####################################################################
-
-  ParameterReleaseFlagsVcExpiryRemoved:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !If
-        - OverrideSettingOfEnvironmentWideFeatureFlag
-        - !Sub "/${AWS::StackName}/release-flags-vc-expiry-removed-not-used-in-dev"
-        - !Sub "/release-flags/vc-expiry-removed"
-      Value: !FindInMap [ VcExpiryRemoved, Environment, !Ref Environment ]
-      Type: String
-      Description: Expiry date release toggle
-
-  ReleaseFlagsVcContainsUniqueIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
-      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
-      Type: String
-      Description: Verifiable Credential Contains UniqueId Mapping
 
   ParameterDocumentCheckResultTableName:
     Type: AWS::SSM::Parameter

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/pact/IssueCredentialHandlerTest.java
@@ -77,8 +77,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
-import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED;
 
 // For static tests against potential new contracts
 @Tag("Pact")
@@ -135,8 +133,6 @@ class IssueCredentialHandlerTest {
     void pactSetup(PactVerificationContext context)
             throws IOException, NoSuchAlgorithmException, InvalidKeySpecException, JOSEException {
 
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_EXPIRY_REMOVED, true);
-        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, true);
         environmentVariables.set("INCLUDE_VC_KID", "false");
         environmentVariables.set("POWERTOOLS_METRICS_NAMESPACE", "StackName");
 

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialServiceTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.drivingpermit.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
@@ -202,10 +203,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         assertEquals(UNIT_TEST_VC_ISSUER, claimsSet.get("iss").textValue());
         assertEquals(UNIT_TEST_SUBJECT, claimsSet.get("sub").textValue());
 
-        long notBeforeTime = claimsSet.get("nbf").asLong();
-        final long expirationTime = claimsSet.get("exp").asLong();
-        assertEquals(expirationTime, notBeforeTime + UNIT_TEST_MAX_JWT_TTL);
-
+        assertNotNull(claimsSet.get("nbf"));
+        assertTrue(claimsSet.get("nbf").asLong() > 0);
         ECDSAVerifier ecVerifier = new ECDSAVerifier(ECKey.parse(TestFixtures.EC_PUBLIC_JWK_1));
         assertTrue(signedJWT.verify(ecVerifier));
     }


### PR DESCRIPTION
## Proposed changes

### What changed

- CRI Common Lib upgrade to 9.0.1
- Limeade updated to 1.2.2
- Open tel updated to 2.28.1-alpha

### Why did it change

- As part of Dependabot updates

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2213](https://govukverify.atlassian.net/browse/LIME-2213)


[LIME-2213]: https://govukverify.atlassian.net/browse/LIME-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ