### PR TITLE
LIME-2213: Remove SSM param permissions for deprecated feature flags.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -220,14 +220,14 @@
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 973
+        "line_number": 971
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/lambda/template.yaml",
         "hashed_secret": "7bfab66d307c824a52622af284a0bd486d6525e3",
         "is_verified": false,
-        "line_number": 980
+        "line_number": 978
       }
     ],
     "lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/aws/certificate/utils/CryptoUtils.java": [
@@ -478,5 +478,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-08T14:12:32Z"
+  "generated_at": "2026-06-09T12:36:46Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -805,8 +805,6 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/JwtTtlUnit"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
-              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/release-flags/vc-expiry-removed"
-              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/release-flags/vc-contains-unique-id"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow


### PR DESCRIPTION
## Proposed changes

### What changed

- Remove `ssm:GetParameter` permissions for `vc-expiry-removed` and `vc-contains-unique-id`

### Why did it change

- Follow up clean up PR for removing the deprecated feature flags as part of cri lib update

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2213](https://govukverify.atlassian.net/browse/LIME-2213)

[LIME-2213]: https://govukverify.atlassian.net/browse/LIME-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ