### PR TITLE
LIME-2054 - Add functionality to query cloud watch log groups within …

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 			libs.aws.lambda.java.events,
 			libs.aws.sdk.dynamodb,
 			libs.aws.sdk.secretsmanager,
+			libs.aws.sdk.cloudwatchlogs,
+			libs.aws.sdk.cloudformation,
 			libs.aws.sdk.crt.client,
 			libs.cri.common.lib,
 			platform(libs.jackson.bom),

--- a/acceptance-tests/run-local-tests.sh
+++ b/acceptance-tests/run-local-tests.sh
@@ -13,6 +13,10 @@ then
 fi
 
 ##### Ask fundamental test questions
+read -p "What is your AWS stack name? [previous=$AWS_STACK_NAME] " AWS_STACK_NAME_NEW
+
+read -p "What is your AWS profile? [previous=$AWS_PROFILE] " AWS_PROFILE_NEW
+
 read -p "What browser do you want to use? [previous=$BROWSER] " BROWSER_NEW
 
 read -p "What environment are you running against? [previous=$ENVIRONMENT] " ENVIRONMENT_NEW
@@ -26,6 +30,8 @@ read -p "Are you including Backend tests? [previous=$BACKEND] " BACKEND_NEW
 read -p "Which tag would you like to run (include the @ in the name)? [previous=$TAG] " TAG_NEW
 
 ##### Update env vars with answers if set
+AWS_STACK_NAME=$([ -z "$AWS_STACK_NAME_NEW" ] && echo "$AWS_STACK_NAME" || echo "$AWS_STACK_NAME_NEW")
+AWS_PROFILE=$([ -z "$AWS_PROFILE_NEW" ] && echo "$AWS_PROFILE" || echo "$AWS_PROFILE_NEW")
 BROWSER=$([[ -z "$BROWSER_NEW" ]] && echo "$BROWSER" || echo "$BROWSER_NEW")
 ENVIRONMENT=$([[ -z "$ENVIRONMENT_NEW" ]] && echo "$ENVIRONMENT" || echo "$ENVIRONMENT_NEW")
 LOCAL=$([ -z "$LOCAL_NEW" ] && echo "$LOCAL" || echo "$LOCAL_NEW")
@@ -35,6 +41,12 @@ TAG=$([ -z "$TAG_NEW" ] && echo "$TAG" || echo "$TAG_NEW")
 
 ##### Export browser for test run
 export BROWSER=${BROWSER}
+
+##### Export AWS stack name
+export AWS_STACK_NAME=${AWS_STACK_NAME}
+
+##### Export AWS profile
+export AWS_PROFILE=${AWS_PROFILE}
 
 ##### Export environment for test run
 export ENVIRONMENT=${ENVIRONMENT}
@@ -101,6 +113,8 @@ echo "BACKEND=${BACKEND}" >> test-args.conf
 echo "API_GATEWAY_ID_PRIVATE=${API_GATEWAY_ID_PRIVATE}" >> test-args.conf
 echo "API_GATEWAY_ID_PUBLIC=${API_GATEWAY_ID_PUBLIC}" >> test-args.conf
 echo "TAG=${TAG}" >> test-args.conf
+echo "AWS_STACK_NAME=${AWS_STACK_NAME}" >> test-args.conf
+echo "AWS_PROFILE=${AWS_PROFILE}" >> test-args.conf
 
 
 ###### Run tests

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DLCommonPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DLCommonPageObject.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 
 import static gov.di_ipv_drivingpermit.pages.Headers.IPV_CORE_STUB;
@@ -36,6 +37,9 @@ public class DLCommonPageObject extends UniversalSteps {
 
     private static final String STUB_VC_PAGE_TITLE = "IPV Core Stub Credential Result - GOV.UK";
     private static final String STUB_ERROR_PAGE_TITLE = "IPV Core Stub - GOV.UK";
+
+    private static String vcTxn;
+    private static Instant feTestStartTime;
 
     @FindBy(xpath = "//*[@id=\"main-content\"]/p/a/button")
     public WebElement visitCredentialIssuers;
@@ -144,9 +148,36 @@ public class DLCommonPageObject extends UniversalSteps {
         } else {
             assertExpectedPage(STUB_VC_PAGE_TITLE, true);
             assertURLContains("callback");
+            feTestStartTime = Instant.now().minusSeconds(30);
             BrowserUtils.waitForVisibility(viewResponse, MAX_WAIT_SEC);
             viewResponse.click();
+            extractAndStoreTxnFromVc();
         }
+    }
+
+    private void extractAndStoreTxnFromVc() {
+        try {
+            BrowserUtils.waitForVisibility(jsonPayload, MAX_WAIT_SEC);
+            JsonNode vcNode = getJsonNode(jsonPayload.getText(), "vc");
+            if (vcNode != null) {
+                List<JsonNode> evidence = getListOfNodes(vcNode, "evidence");
+                JsonNode txnNode = evidence.get(0).get("txn");
+                if (txnNode != null && !txnNode.isNull()) {
+                    vcTxn = txnNode.asText();
+                    LOGGER.info("Captured txn from VC: '{}'", vcTxn);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not extract txn from VC: {}", e.getMessage());
+        }
+    }
+
+    public static String getVcTxn() {
+        return vcTxn;
+    }
+
+    public static Instant getFeTestStartTime() {
+        return feTestStartTime;
     }
 
     // -----------------------

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicenceAPIPage.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpRequest;
 import java.text.ParseException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -66,6 +67,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
 
     private static Boolean retry;
     private static String drivingLicenceCheckResponse;
+    private static Instant testStartTime;
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.MAPPER;
 
     private final ConfigurationService configurationService =
@@ -325,6 +327,7 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
                 OBJECT_MAPPER.readValue(sessionResponse, new TypeReference<>() {});
         sessionId = deserialisedResponse.get("session_id");
         state = deserialisedResponse.get("state");
+        testStartTime = Instant.now().minusSeconds(30);
         // Capture client id for using later in the auth request
         Map<String, String> deserialisedSessionResponse =
                 OBJECT_MAPPER.readValue(sessionRequestBody, new TypeReference<>() {});
@@ -1002,6 +1005,14 @@ public class DrivingLicenceAPIPage extends DrivingLicencePageObject {
     private static final String getBasicAuthenticationHeader(String username, String password) {
         String valueToEncode = username + ":" + password;
         return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+    }
+
+    public static String getSessionId() {
+        return sessionId;
+    }
+
+    public static Instant getTestStartTime() {
+        return testStartTime;
     }
 
     private String getAccessTokenRequest(String criId) throws IOException, InterruptedException {

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/CloudWatchLogStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/CloudWatchLogStepDefs.java
@@ -1,0 +1,114 @@
+package gov.di_ipv_drivingpermit.step_definitions;
+
+import gov.di_ipv_drivingpermit.pages.DLCommonPageObject;
+import gov.di_ipv_drivingpermit.pages.DrivingLicenceAPIPage;
+import gov.di_ipv_drivingpermit.utilities.CloudWatchLogService;
+import io.cucumber.java.en.Then;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CloudWatchLogStepDefs {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudWatchLogStepDefs.class);
+
+    private final CloudWatchLogService cloudWatchLogService = new CloudWatchLogService();
+
+    private final String stackName = System.getenv("AWS_STACK_NAME");
+
+    @Then("the {string} lambda logs should contain {string}")
+    public void lambdaLogsShouldContain(String logGroupLogicalId, String expectedMessage) {
+        if (stackName == null) {
+            LOGGER.info("Skipping CloudWatch log assertion — AWS_STACK_NAME not set");
+            return;
+        }
+
+        String sessionId = DrivingLicenceAPIPage.getSessionId();
+        List<String> logMessages;
+
+        if (sessionId != null) {
+            logMessages =
+                    cloudWatchLogService.getLogMessages(
+                            stackName,
+                            logGroupLogicalId,
+                            sessionId,
+                            DrivingLicenceAPIPage.getTestStartTime());
+        } else {
+            String txn = DLCommonPageObject.getVcTxn();
+            LOGGER.info("No sessionId available, falling back to txn-based lookup: '{}'", txn);
+            logMessages =
+                    cloudWatchLogService.getLogMessagesByTxn(
+                            stackName,
+                            logGroupLogicalId,
+                            txn,
+                            DLCommonPageObject.getFeTestStartTime());
+        }
+
+        logMessages.forEach(message -> LOGGER.info("  {}", message));
+
+        boolean found = logMessages.stream().anyMatch(message -> message.contains(expectedMessage));
+
+        LOGGER.info(
+                "Log assertion for message '{}': {}",
+                expectedMessage,
+                found ? "FOUND" : "NOT FOUND");
+
+        assertTrue(
+                found,
+                "Expected log message not found in '"
+                        + logGroupLogicalId
+                        + "' logs: '"
+                        + expectedMessage
+                        + "'");
+    }
+
+    @Then("the {string} lambda logs should not contain {string}")
+    public void lambdaLogsShouldNotContain(String logGroupLogicalId, String unexpectedMessage) {
+        if (stackName == null) {
+            LOGGER.info("Skipping CloudWatch log assertion — AWS_STACK_NAME not set");
+            return;
+        }
+
+        String sessionId = DrivingLicenceAPIPage.getSessionId();
+        List<String> logMessages;
+
+        if (sessionId != null) {
+            logMessages =
+                    cloudWatchLogService.getLogMessages(
+                            stackName,
+                            logGroupLogicalId,
+                            sessionId,
+                            DrivingLicenceAPIPage.getTestStartTime());
+        } else {
+            String txn = DLCommonPageObject.getVcTxn();
+            LOGGER.info("No sessionId available, falling back to txn-based lookup: '{}'", txn);
+            logMessages =
+                    cloudWatchLogService.getLogMessagesByTxn(
+                            stackName,
+                            logGroupLogicalId,
+                            txn,
+                            DLCommonPageObject.getFeTestStartTime());
+        }
+
+        logMessages.forEach(message -> LOGGER.info("  {}", message));
+
+        boolean found =
+                logMessages.stream().anyMatch(message -> message.contains(unexpectedMessage));
+
+        LOGGER.info(
+                "Negative log assertion for message '{}': {}",
+                unexpectedMessage,
+                found ? "UNEXPECTEDLY FOUND" : "CORRECTLY ABSENT");
+
+        assertTrue(
+                !found,
+                "Unexpected log message found in '"
+                        + logGroupLogicalId
+                        + "' logs: '"
+                        + unexpectedMessage
+                        + "'");
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/PiiLogScanStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/PiiLogScanStepDefs.java
@@ -1,0 +1,69 @@
+package gov.di_ipv_drivingpermit.step_definitions;
+
+import gov.di_ipv_drivingpermit.utilities.CloudWatchLogService;
+import gov.di_ipv_drivingpermit.utilities.PiiTermsCollector;
+import gov.di_ipv_drivingpermit.utilities.TestRunContext;
+import io.cucumber.java.BeforeAll;
+import io.cucumber.java.AfterAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PiiLogScanStepDefs {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PiiLogScanStepDefs.class);
+
+    private static final List<String> LOG_GROUPS_TO_SCAN =
+            List.of("DrivingPermitCheckingFunctionLogGroup", "IssueCredentialFunctionLogGroup");
+
+    @BeforeAll
+    public static void recordSuiteStart() {
+        TestRunContext.recordSuiteStart();
+    }
+
+    @AfterAll
+    public static void scanLogsForPii() {
+        String stackName = System.getenv("AWS_STACK_NAME");
+        if (stackName == null) {
+            LOGGER.info("Skipping PII log scan — AWS_STACK_NAME not set");
+            return;
+        }
+
+        if (TestRunContext.getSuiteStartTime() == null) {
+            LOGGER.warn("Skipping PII log scan — suite start time not recorded");
+            return;
+        }
+
+        Set<String> piiTerms = PiiTermsCollector.collectFromAllTestUsers();
+        LOGGER.info("PII scan: checking {} terms across {} log groups", piiTerms.size(), LOG_GROUPS_TO_SCAN.size());
+
+        CloudWatchLogService cloudWatchLogService = new CloudWatchLogService();
+        List<String> violations = new ArrayList<>();
+
+        for (String logGroup : LOG_GROUPS_TO_SCAN) {
+            for (String term : piiTerms) {
+                List<String> matches =
+                        cloudWatchLogService.scanForTerm(
+                                stackName, logGroup, term, TestRunContext.getSuiteStartTime());
+                if (!matches.isEmpty()) {
+                    LOGGER.error(
+                            "PII DETECTED in '{}': term '{}' found in {} log event(s)",
+                            logGroup,
+                            term,
+                            matches.size());
+                    matches.forEach(match -> LOGGER.error("  {}", match));
+                    violations.add("'" + term + "' found in " + logGroup);
+                }
+            }
+        }
+
+        assertTrue(
+                violations.isEmpty(),
+                "PII detected in CloudWatch logs after test run: " + violations);
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/CloudWatchLogService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/CloudWatchLogService.java
@@ -1,0 +1,204 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourceRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilterLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilteredLogEvent;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public class CloudWatchLogService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudWatchLogService.class);
+    private static final int INITIAL_DELAY_MS = 10000;
+    private static final int RETRY_INTERVAL_MS = 5000;
+    private static final int MAX_RETRIES = 6;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final CloudWatchLogsClient logsClient;
+    private final CloudFormationClient cfnClient;
+    private String cachedJourneyId;
+
+    public CloudWatchLogService() {
+        DefaultCredentialsProvider credentials = DefaultCredentialsProvider.builder().build();
+        this.logsClient =
+                CloudWatchLogsClient.builder()
+                        .region(Region.EU_WEST_2)
+                        .credentialsProvider(credentials)
+                        .build();
+        this.cfnClient =
+                CloudFormationClient.builder()
+                        .region(Region.EU_WEST_2)
+                        .credentialsProvider(credentials)
+                        .build();
+    }
+
+    /**
+     * Two-step log retrieval: 1. Query by sessionId to find the govuk_signin_journey_id 2. Re-query
+     * by govuk_signin_journey_id to get all correlated log messages
+     *
+     * @param stackName the CloudFormation stack name
+     * @param logGroupLogicalId the CloudFormation logical ID of the log group resource
+     * @param sessionId the session ID to locate the journey ID
+     * @param startTime the earliest log event timestamp to include
+     */
+    public List<String> getLogMessages(
+            String stackName, String logGroupLogicalId, String sessionId, Instant startTime) {
+        String logGroupName = resolveLogGroupName(stackName, logGroupLogicalId);
+        LOGGER.info("Resolved log group: '{}'", logGroupName);
+
+        String journeyId = resolveJourneyId(logGroupName, sessionId, startTime);
+        LOGGER.info("Resolved govuk_signin_journey_id: '{}'", journeyId);
+
+        List<String> messages = queryByJourneyId(logGroupName, journeyId, startTime);
+
+        LOGGER.info(
+                "CloudWatch query on '{}' with journey ID '{}' returned {} events",
+                logGroupName,
+                journeyId,
+                messages.size());
+        return messages;
+    }
+
+    /**
+     * Two-step log retrieval by txn — used for FE UI journeys where sessionId is unavailable.
+     * Resolves the govuk_signin_journey_id from the txn on first call and caches it for subsequent
+     * calls within the same scenario (e.g. checking multiple log groups).
+     *
+     * @param stackName the CloudFormation stack name
+     * @param logGroupLogicalId the CloudFormation logical ID of the log group resource
+     * @param txn the transaction ID from the VC evidence
+     * @param startTime the earliest log event timestamp to include
+     */
+    public List<String> getLogMessagesByTxn(
+            String stackName, String logGroupLogicalId, String txn, Instant startTime) {
+        String logGroupName = resolveLogGroupName(stackName, logGroupLogicalId);
+        LOGGER.info("Resolved log group: '{}'", logGroupName);
+
+        if (cachedJourneyId == null) {
+            cachedJourneyId = resolveJourneyId(logGroupName, txn, startTime);
+            LOGGER.info("Resolved and cached govuk_signin_journey_id: '{}'", cachedJourneyId);
+        } else {
+            LOGGER.info("Reusing cached govuk_signin_journey_id: '{}'", cachedJourneyId);
+        }
+
+        List<String> messages = queryByJourneyId(logGroupName, cachedJourneyId, startTime);
+
+        LOGGER.info(
+                "CloudWatch query on '{}' with journey ID '{}' returned {} events",
+                logGroupName,
+                cachedJourneyId,
+                messages.size());
+        return messages;
+    }
+
+    /**
+     * Queries by sessionId and extracts the govuk_signin_journey_id, retrying to allow for
+     * CloudWatch log ingestion delay.
+     */
+    private String resolveJourneyId(String logGroupName, String sessionId, Instant startTime) {
+        sleep(INITIAL_DELAY_MS);
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            List<String> sessionLogs = filterEvents(logGroupName, sessionId, startTime);
+            LOGGER.info(
+                    "Attempt {}/{}: found {} log events matching sessionId '{}'",
+                    attempt,
+                    MAX_RETRIES,
+                    sessionLogs.size(),
+                    sessionId);
+            Optional<String> journeyId =
+                    sessionLogs.stream()
+                            .map(this::parseJourneyId)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .findFirst();
+            if (journeyId.isPresent()) {
+                return journeyId.get();
+            }
+            if (attempt < MAX_RETRIES) {
+                sleep(RETRY_INTERVAL_MS);
+            }
+        }
+        throw new IllegalStateException(
+                "Could not find govuk_signin_journey_id in logs for sessionId: " + sessionId);
+    }
+
+    private List<String> queryByJourneyId(
+            String logGroupName, String journeyId, Instant startTime) {
+        return filterEvents(logGroupName, journeyId, startTime);
+    }
+
+    private List<String> filterEvents(
+            String logGroupName, String filterPattern, Instant startTime) {
+        return logsClient
+                .filterLogEvents(
+                        FilterLogEventsRequest.builder()
+                                .logGroupName(logGroupName)
+                                .filterPattern("\"" + filterPattern + "\"")
+                                .startTime(startTime.toEpochMilli())
+                                .build())
+                .events()
+                .stream()
+                .map(FilteredLogEvent::message)
+                .toList();
+    }
+
+    private Optional<String> parseJourneyId(String logMessage) {
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(logMessage);
+            JsonNode journeyIdNode = node.get("govuk_signin_journey_id");
+            if (journeyIdNode != null && !journeyIdNode.isNull()) {
+                return Optional.of(journeyIdNode.asText());
+            }
+        } catch (Exception _) {
+            // not a JSON log line, skip
+        }
+        return Optional.empty();
+    }
+
+    private String resolveLogGroupName(String stackName, String logGroupLogicalId) {
+        LOGGER.info(
+                "Resolving log group for stack '{}' logical ID '{}'", stackName, logGroupLogicalId);
+        return cfnClient
+                .describeStackResource(
+                        DescribeStackResourceRequest.builder()
+                                .stackName(stackName)
+                                .logicalResourceId(logGroupLogicalId)
+                                .build())
+                .stackResourceDetail()
+                .physicalResourceId();
+    }
+
+    /**
+     * Scans a log group for any occurrence of a given term within the time window.
+     *
+     * @param stackName the CloudFormation stack name
+     * @param logGroupLogicalId the CloudFormation logical ID of the log group resource
+     * @param term the term to search for
+     * @param startTime the earliest log event timestamp to include
+     * @return matching log events
+     */
+    public List<String> scanForTerm(
+            String stackName, String logGroupLogicalId, String term, Instant startTime) {
+        String logGroupName = resolveLogGroupName(stackName, logGroupLogicalId);
+        return filterEvents(logGroupName, term, startTime);
+    }
+
+    @SuppressWarnings("java:S2925")
+    private void sleep(int ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException _) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/PiiTermsCollector.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/PiiTermsCollector.java
@@ -1,0 +1,49 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PiiTermsCollector {
+
+    // Exclude values too short or generic to be meaningful PII search terms
+    private static final int MIN_TERM_LENGTH = 4;
+
+    private PiiTermsCollector() {}
+
+    public static Set<String> collectFromAllTestUsers() {
+        TestDataCreator.createDefaultResponses();
+
+        return Stream.of(
+                        TestDataCreator.dvaTestUsers.values(),
+                        TestDataCreator.dvlaTestUsers.values())
+                .flatMap(Collection::stream)
+                .flatMap(PiiTermsCollector::extractPiiTerms)
+                .filter(term -> term != null && term.length() >= MIN_TERM_LENGTH)
+                .collect(Collectors.toSet());
+    }
+
+    private static Stream<String> extractPiiTerms(TestInput user) {
+        return Arrays.stream(
+                new String[] {
+                    user.getFirstName(),
+                    user.getLastName(),
+                    user.getMiddleNames(),
+                    user.getLicenceNumber(),
+                    user.getPostcode(),
+                    fullDob(user)
+                });
+    }
+
+    private static String fullDob(TestInput user) {
+        if (user.getBirthYear() == null) return null;
+        return user.getBirthYear() + "-" + pad(user.getBirthMonth()) + "-" + pad(user.getBirthDay());
+    }
+
+    private static String pad(String value) {
+        if (value == null) return "00";
+        return value.length() == 1 ? "0" + value : value;
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestRunContext.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestRunContext.java
@@ -1,0 +1,20 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import java.time.Instant;
+
+public class TestRunContext {
+
+    private static Instant suiteStartTime;
+
+    private TestRunContext() {}
+
+    public static void recordSuiteStart() {
+        if (suiteStartTime == null) {
+            suiteStartTime = Instant.now().minusSeconds(30);
+        }
+    }
+
+    public static Instant getSuiteStartTime() {
+        return suiteStartTime;
+    }
+}

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVACRIAPI.feature
@@ -46,7 +46,7 @@ Feature: DVA CRI API
       | context       | personalNumber | expiryDate | issueDate  | issuedBy | fullAddress | JSONPayloadRequest                     | cri_internal_error_code | cri_internal_error_message  |
       | check_details | 66778899       | 2042-10-01 | 2018-04-19 | DVA      |             | DVAAuthSourceInvalidAddressJsonPayload | 1001                    | Form Data failed validation |
 
-  @pre-merge
+  @pre-merge @cloudwatch_validation
   Scenario: DVA Driving Licence Happy path
     Given Driving Licence user has the user identity in the form of a signed JWT string for CRI Id driving-licence-cri-dev and row number 6
     And Driving Licence user sends a POST request to session endpoint
@@ -57,6 +57,8 @@ Feature: DVA CRI API
     Then User requests Driving Licence CRI VC
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
+    And the "DrivingPermitCheckingFunctionLogGroup" lambda logs should contain "Document verified"
+    And the "IssueCredentialFunctionLogGroup" lambda logs should contain "Sending AuditEvent VC_ISSUED"
 
   @pre-merge
   Scenario: DVA Driving Licence Retry Journey Happy Path

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVA/DVADrivingLicence.feature
@@ -13,7 +13,7 @@ Feature: DVA Driving Licence Test
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – GOV.UK One Login
     And I see a form requesting DVA LicenceNumber
 
-  @smoke-build @stub @uat @traffic
+  @smoke-build @stub @uat @traffic @cloudwatch_validation
   Scenario Outline: DVA - Happy path
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue and waits for page navigation
@@ -21,6 +21,8 @@ Feature: DVA Driving Licence Test
     And JSON payload should contain validity score 2, strength score 3 and type IdentityCheck
     And JSON response should contain personal number 12345678 same as given Driving Licence
     And JSON response should contain JTI field
+    And the "DrivingPermitCheckingFunctionLogGroup" lambda logs should contain "Document verified"
+    And the "IssueCredentialFunctionLogGroup" lambda logs should contain "Sending AuditEvent VC_ISSUED"
 
     Examples:
       | DVADrivingLicenceSubject             |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLA/DVLACRIAPI.feature
@@ -62,6 +62,8 @@ Feature: DrivingLicence CRI API
     And Driving Licence VC should contain validityScore 2 and strengthScore 3
     And Driving Licence VC should contain checkMethod data and identityCheckPolicy published in success checkDetails
     And Driving Licence VC should contain JTI field
+    And the "DrivingPermitCheckingFunctionLogGroup" lambda logs should contain "Document verified"
+    And the "IssueCredentialFunctionLogGroup" lambda logs should contain "Sending AuditEvent VC_ISSUED"
 
   @pre-merge
   Scenario: DVLA Password rotation check

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,8 @@ aws-sdk-lambda = { module = "software.amazon.awssdk:lambda" }
 aws-sdk-sqs = { module = "software.amazon.awssdk:sqs" }
 aws-sdk-acm = { module = "software.amazon.awssdk:acm" }
 aws-sdk-secretsmanager = { module = "software.amazon.awssdk:secretsmanager" }
+aws-sdk-cloudwatchlogs = { module = "software.amazon.awssdk:cloudwatchlogs" }
+aws-sdk-cloudformation = { module = "software.amazon.awssdk:cloudformation" }
 aws-cdk-lib = { module = "software.amazon.awscdk:aws-cdk-lib", version.ref = "aws_cdk_lib" }
 
 # Shared


### PR DESCRIPTION
…API Tests

CloudWatchLogService created:
Resolves the Log Group from the CloudFormation Logical ID Peerforms a 2 step query: A. finds the govuk_signin_journey_id by searching for the sessionId  B. fetches all logs for that Test Journey Added retry up to 6 times with delays to handle cloudwatch ingestion delays

Added CloudWatchLogStepDefs - validates the correct log contains the correct value. Will skip these steps if the AWS_STACK_NAME is not set

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2054](https://govukverify.atlassian.net/browse/LIME-2054)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2054]: https://govukverify.atlassian.net/browse/LIME-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ