### PR TITLE
LIME-2053 - Add functionality to query cloud watch log groups within …

### DIFF
--- a/.github/workflows/run-pre-merge-integration-tests.yml
+++ b/.github/workflows/run-pre-merge-integration-tests.yml
@@ -162,6 +162,12 @@ jobs:
           export API_GATEWAY_ID_PRIVATE="${API_GATEWAY_ID_PRIVATE}"
           export API_GATEWAY_ID_PUBLIC="${API_GATEWAY_ID_PUBLIC}"
           export API_GATEWAY_KEY="${APIGW_API_KEY}"
+          export AWS_STACK_NAME="${STACK_NAME}"
+          ECS_LOG_GROUP_SSM=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/ECS_LOG_GROUP_NAME" --region eu-west-2 2>/dev/null || true)
+          if [ -n "$ECS_LOG_GROUP_SSM" ]; then
+            export ECS_LOG_GROUP_NAME=$(echo "$ECS_LOG_GROUP_SSM" | jq -r '.Parameter.Value')
+            echo "ECS_LOG_GROUP_NAME ${ECS_LOG_GROUP_NAME}"
+          fi
           AC_TEST_ONLY=true ./gradlew acceptance-tests:cucumber -P tags=@pre-merge
 
       - name: Delete pre-merge test stack

--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,28 +1,34 @@
 # di-ipv-cri-dl-test
 
-This folder has be created as a central location for any work related to Driving Licence CRI testing.
+This folder has been created as a central location for any work related to Driving Licence CRI testing.
 
 ## Build
 
 Build with `./gradlew`
 
-### Run tests
+## Run tests
 
-When running locally the following environment variables must be set
+For first-time setup, run `./run-local-tests.sh` which will guide you through configuration and save your answers to `test-args.conf`.
 
-ENVIRONMENT \
-AWS_STACK_NAME \
-API_GATEWAY_ID_PRIVATE \
-apiBaseUrl \
-coreStubUrl \
-coreStubUsername \
-coreStubPassword \
-passportCriUrl  \
-orchestratorStubUrl
+To run tests directly: `./gradlew cucumber -P tags=@dl_CRI`
 
-Speak to a member of the test team for these values
-When running in the pipeline these will be taken from AWS
+### Environment variables
 
-Run tests with `./gradlew cucumber -P tags=@dl_CRI`
-or if its your first time running these tests `./run-local-tests.sh` will help you setup
-and run the tests
+|         Variable         | Required |                                       Description                                       |
+|--------------------------|----------|-----------------------------------------------------------------------------------------|
+| `ENVIRONMENT`            | Yes      | Target environment e.g. `dev`                                                           |
+| `AWS_STACK_NAME`         | No       | CloudFormation stack name. If not set, PII log scanning is skipped                      |
+| `ECS_LOG_GROUP_NAME`     | No       | ECS CloudWatch log group name for PII scanning. If not set, ECS log scanning is skipped |
+| `BROWSER`                | Yes      | Browser to use e.g. `chrome-headless`                                                   |
+| `LOCAL`                  | Yes      | Set to `yes` if using a local stub                                                      |
+| `E2E`                    | Yes      | Set to `yes` to include E2E tests                                                       |
+| `BACKEND`                | Yes      | Set to `yes` to include backend tests                                                   |
+| `TAG`                    | Yes      | Cucumber tag to run e.g. `@test`                                                        |
+| `CORE_STUB_URL`          | No       | Stub URL (without protocol)                                                             |
+| `CORE_STUB_USERNAME`     | No       | Stub username                                                                           |
+| `CORE_STUB_PASSWORD`     | No       | Stub password                                                                           |
+| `ORCHESTRATOR_URL`       | No       | Required when `E2E=yes`                                                                 |
+| `API_GATEWAY_ID_PRIVATE` | No       | Required when `BACKEND=yes`                                                             |
+| `API_GATEWAY_ID_PUBLIC`  | No       | Required when `BACKEND=yes`                                                             |
+
+Speak to a member of the test team for credential values. When running in the pipeline these will be taken from AWS.

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 			libs.aws.lambda.java.events,
 			libs.aws.sdk.dynamodb,
 			libs.aws.sdk.secretsmanager,
+			libs.aws.sdk.cloudwatchlogs,
+			libs.aws.sdk.cloudformation,
 			libs.aws.sdk.crt.client,
 			libs.cri.common.lib,
 			platform(libs.jackson.bom),

--- a/acceptance-tests/run-local-tests.sh
+++ b/acceptance-tests/run-local-tests.sh
@@ -13,6 +13,10 @@ then
 fi
 
 ##### Ask fundamental test questions
+read -p "What is your AWS stack name? (leave blank to skip PII scan) [previous=$AWS_STACK_NAME] " AWS_STACK_NAME_NEW
+
+read -p "What is the ECS log group name for PII scanning? (leave blank to skip) [previous=$ECS_LOG_GROUP_NAME] " ECS_LOG_GROUP_NAME_NEW
+
 read -p "What browser do you want to use? [previous=$BROWSER] " BROWSER_NEW
 
 read -p "What environment are you running against? [previous=$ENVIRONMENT] " ENVIRONMENT_NEW
@@ -26,6 +30,8 @@ read -p "Are you including Backend tests? [previous=$BACKEND] " BACKEND_NEW
 read -p "Which tag would you like to run (include the @ in the name)? [previous=$TAG] " TAG_NEW
 
 ##### Update env vars with answers if set
+AWS_STACK_NAME=$([ -z "$AWS_STACK_NAME_NEW" ] && echo "$AWS_STACK_NAME" || echo "$AWS_STACK_NAME_NEW")
+ECS_LOG_GROUP_NAME=$([ -z "$ECS_LOG_GROUP_NAME_NEW" ] && echo "$ECS_LOG_GROUP_NAME" || echo "$ECS_LOG_GROUP_NAME_NEW")
 BROWSER=$([[ -z "$BROWSER_NEW" ]] && echo "$BROWSER" || echo "$BROWSER_NEW")
 ENVIRONMENT=$([[ -z "$ENVIRONMENT_NEW" ]] && echo "$ENVIRONMENT" || echo "$ENVIRONMENT_NEW")
 LOCAL=$([ -z "$LOCAL_NEW" ] && echo "$LOCAL" || echo "$LOCAL_NEW")
@@ -35,6 +41,12 @@ TAG=$([ -z "$TAG_NEW" ] && echo "$TAG" || echo "$TAG_NEW")
 
 ##### Export browser for test run
 export BROWSER=${BROWSER}
+
+##### Export AWS stack name
+export AWS_STACK_NAME=${AWS_STACK_NAME}
+
+##### Export ECS log group name (optional)
+export ECS_LOG_GROUP_NAME=${ECS_LOG_GROUP_NAME}
 
 ##### Export environment for test run
 export ENVIRONMENT=${ENVIRONMENT}
@@ -101,9 +113,15 @@ echo "BACKEND=${BACKEND}" >> test-args.conf
 echo "API_GATEWAY_ID_PRIVATE=${API_GATEWAY_ID_PRIVATE}" >> test-args.conf
 echo "API_GATEWAY_ID_PUBLIC=${API_GATEWAY_ID_PUBLIC}" >> test-args.conf
 echo "TAG=${TAG}" >> test-args.conf
+echo "AWS_STACK_NAME=${AWS_STACK_NAME}" >> test-args.conf
+echo "ECS_LOG_GROUP_NAME=${ECS_LOG_GROUP_NAME}" >> test-args.conf
 
 
 ###### Run tests
 actestPath="${PWD}"
-cd ../ && AC_TEST_ONLY=true ./gradlew clean cucumber -P tags="${TAG}"
+if [ -n "${AWS_STACK_NAME}" ]; then
+  cd ../ && aws-vault exec "${AWS_PROFILE:-dl-dev}" -- bash -c "AC_TEST_ONLY=true ./gradlew clean cucumber -P tags='${TAG}'"
+else
+  cd ../ && AC_TEST_ONLY=true ./gradlew clean cucumber -P tags="${TAG}"
+fi
 cd "${actestPath}" || exit

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -28,6 +28,8 @@ else
   export ENVIRONMENT="${ENVIRONMENT}"
 fi
 
+export AWS_STACK_NAME="${STACK_NAME}"
+
 echo "ENVIRONMENT ${ENVIRONMENT}"
 echo "STACK_NAME ${STACK_NAME}"
 
@@ -66,6 +68,12 @@ if [ "${STACK_NAME}" != "local" ]; then
 
     eval $(echo "export ${NAME}=${VALUE}")
   done
+
+  ECS_LOG_GROUP_SSM=$(aws ssm get-parameter --name "/tests/$STACK_NAME/ECS_LOG_GROUP_NAME" --region eu-west-2 2>/dev/null || true)
+  if [ -n "$ECS_LOG_GROUP_SSM" ]; then
+    export ECS_LOG_GROUP_NAME=$(echo "$ECS_LOG_GROUP_SSM" | jq -r '.Parameter.Value')
+    echo "ECS_LOG_GROUP_NAME ${ECS_LOG_GROUP_NAME}"
+  fi
 else
   export JOURNEY_TAG="${TEST_TAG}"
 fi

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/PiiLogScanStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/PiiLogScanStepDefs.java
@@ -1,0 +1,99 @@
+package gov.di_ipv_drivingpermit.step_definitions;
+
+import gov.di_ipv_drivingpermit.utilities.CloudWatchLogService;
+import gov.di_ipv_drivingpermit.utilities.PiiTermsCollector;
+import gov.di_ipv_drivingpermit.utilities.TestRunContext;
+import io.cucumber.java.AfterAll;
+import io.cucumber.java.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PiiLogScanStepDefs {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PiiLogScanStepDefs.class);
+
+    private static final List<String> CFN_LOG_GROUPS =
+            List.of(
+                    "DrivingPermitCheckingFunctionLogGroup",
+                    "IssueCredentialFunctionLogGroup",
+                    "PersonInfoFunctionLogGroup");
+
+    @BeforeAll
+    public static void recordSuiteStart() {
+        TestRunContext.recordSuiteStart();
+    }
+
+    @AfterAll
+    public static void scanLogsForPii() {
+        String stackName = System.getenv("AWS_STACK_NAME");
+        if (stackName == null || stackName.isBlank()) {
+            LOGGER.info("Skipping PII log scan — AWS_STACK_NAME not set");
+            return;
+        }
+
+        if (TestRunContext.getSuiteStartTime() == null) {
+            LOGGER.warn("Skipping PII log scan — suite start time not recorded");
+            return;
+        }
+
+        Set<String> piiTerms = PiiTermsCollector.collectFromAllTestUsers();
+        String ecsLogGroup = System.getenv("ECS_LOG_GROUP_NAME");
+        if (ecsLogGroup != null && ecsLogGroup.isBlank()) {
+            ecsLogGroup = null;
+        }
+        int totalGroups = CFN_LOG_GROUPS.size() + (ecsLogGroup != null ? 1 : 0);
+        LOGGER.info(
+                "PII scan: checking {} terms across {} log groups", piiTerms.size(), totalGroups);
+
+        CloudWatchLogService cloudWatchLogService = new CloudWatchLogService();
+        List<String> violations = new ArrayList<>();
+
+        for (String logGroup : CFN_LOG_GROUPS) {
+            for (String term : piiTerms) {
+                recordViolations(
+                        cloudWatchLogService.scanForTerm(
+                                stackName, logGroup, term, TestRunContext.getSuiteStartTime()),
+                        logGroup,
+                        term,
+                        violations);
+            }
+        }
+
+        if (ecsLogGroup != null) {
+            LOGGER.info("Scanning ECS log group '{}' for PII", ecsLogGroup);
+            for (String term : piiTerms) {
+                recordViolations(
+                        cloudWatchLogService.scanForTermByDirectName(
+                                ecsLogGroup, term, TestRunContext.getSuiteStartTime()),
+                        ecsLogGroup,
+                        term,
+                        violations);
+            }
+        } else {
+            LOGGER.info("Skipping ECS log scan — ECS_LOG_GROUP_NAME not set");
+        }
+
+        assertTrue(
+                violations.isEmpty(),
+                "PII detected in CloudWatch logs after test run: " + violations);
+    }
+
+    private static void recordViolations(
+            List<String> matches, String logGroup, String term, List<String> violations) {
+        if (!matches.isEmpty()) {
+            LOGGER.error(
+                    "PII DETECTED in '{}': term '{}' found in {} log event(s)",
+                    logGroup,
+                    term,
+                    matches.size());
+            matches.forEach(match -> LOGGER.error("  {}", match));
+            violations.add("'" + term + "' found in " + logGroup);
+        }
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/CloudWatchLogService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/CloudWatchLogService.java
@@ -1,0 +1,91 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStackResourceRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilterLogEventsRequest;
+import software.amazon.awssdk.services.cloudwatchlogs.model.FilteredLogEvent;
+
+import java.time.Instant;
+import java.util.List;
+
+public class CloudWatchLogService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudWatchLogService.class);
+    private final CloudWatchLogsClient logsClient;
+    private final CloudFormationClient cfnClient;
+
+    public CloudWatchLogService() {
+        DefaultCredentialsProvider credentials = DefaultCredentialsProvider.builder().build();
+        this.logsClient =
+                CloudWatchLogsClient.builder()
+                        .region(Region.EU_WEST_2)
+                        .credentialsProvider(credentials)
+                        .build();
+        this.cfnClient =
+                CloudFormationClient.builder()
+                        .region(Region.EU_WEST_2)
+                        .credentialsProvider(credentials)
+                        .build();
+    }
+
+    private List<String> filterEvents(
+            String logGroupName, String filterPattern, Instant startTime) {
+        return logsClient
+                .filterLogEvents(
+                        FilterLogEventsRequest.builder()
+                                .logGroupName(logGroupName)
+                                .filterPattern("\"" + filterPattern + "\"")
+                                .startTime(startTime.toEpochMilli())
+                                .build())
+                .events()
+                .stream()
+                .map(FilteredLogEvent::message)
+                .toList();
+    }
+
+    private String resolveLogGroupName(String stackName, String logGroupLogicalId) {
+        LOGGER.info(
+                "Resolving log group for stack '{}' logical ID '{}'", stackName, logGroupLogicalId);
+        return cfnClient
+                .describeStackResource(
+                        DescribeStackResourceRequest.builder()
+                                .stackName(stackName)
+                                .logicalResourceId(logGroupLogicalId)
+                                .build())
+                .stackResourceDetail()
+                .physicalResourceId();
+    }
+
+    /**
+     * Scans a log group for any occurrence of a given term within the time window.
+     *
+     * @param stackName the CloudFormation stack name
+     * @param logGroupLogicalId the CloudFormation logical ID of the log group resource
+     * @param term the term to search for
+     * @param startTime the earliest log event timestamp to include
+     * @return matching log events
+     */
+    public List<String> scanForTerm(
+            String stackName, String logGroupLogicalId, String term, Instant startTime) {
+        String logGroupName = resolveLogGroupName(stackName, logGroupLogicalId);
+        return filterEvents(logGroupName, term, startTime);
+    }
+
+    /**
+     * Scans a log group by its literal name (for log groups outside the CRI stack).
+     *
+     * @param logGroupName the literal CloudWatch log group name
+     * @param term the term to search for
+     * @param startTime the earliest log event timestamp to include
+     * @return matching log events
+     */
+    public List<String> scanForTermByDirectName(
+            String logGroupName, String term, Instant startTime) {
+        return filterEvents(logGroupName, term, startTime);
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/PiiTermsCollector.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/PiiTermsCollector.java
@@ -1,0 +1,53 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PiiTermsCollector {
+
+    // Exclude values too short or generic to be meaningful PII search terms
+    private static final int MIN_TERM_LENGTH = 4;
+
+    private PiiTermsCollector() {}
+
+    public static Set<String> collectFromAllTestUsers() {
+        TestDataCreator.createDefaultResponses();
+
+        return Stream.of(
+                        TestDataCreator.dvaTestUsers.values(),
+                        TestDataCreator.dvlaTestUsers.values())
+                .flatMap(Collection::stream)
+                .flatMap(PiiTermsCollector::extractPiiTerms)
+                .filter(term -> term != null && term.length() >= MIN_TERM_LENGTH)
+                .collect(Collectors.toSet());
+    }
+
+    private static Stream<String> extractPiiTerms(TestInput user) {
+        return Arrays.stream(
+                new String[] {
+                    user.getFirstName(),
+                    user.getLastName(),
+                    user.getMiddleNames(),
+                    user.getLicenceNumber(),
+                    user.getPostcode(),
+                    fullDob(user)
+                });
+    }
+
+    private static String fullDob(TestInput user) {
+        if (user.getBirthYear() == null) return null;
+        return user.getBirthYear()
+                + "-"
+                + pad(user.getBirthMonth())
+                + "-"
+                + pad(user.getBirthDay());
+    }
+
+    private static String pad(String value) {
+        if (value == null) return "00";
+        return value.length() == 1 ? "0" + value : value;
+    }
+}

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestRunContext.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestRunContext.java
@@ -1,0 +1,20 @@
+package gov.di_ipv_drivingpermit.utilities;
+
+import java.time.Instant;
+
+public class TestRunContext {
+
+    private static Instant suiteStartTime;
+
+    private TestRunContext() {}
+
+    public static void recordSuiteStart() {
+        if (suiteStartTime == null) {
+            suiteStartTime = Instant.now().minusSeconds(30);
+        }
+    }
+
+    public static Instant getSuiteStartTime() {
+        return suiteStartTime;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,8 @@ aws-sdk-lambda = { module = "software.amazon.awssdk:lambda" }
 aws-sdk-sqs = { module = "software.amazon.awssdk:sqs" }
 aws-sdk-acm = { module = "software.amazon.awssdk:acm" }
 aws-sdk-secretsmanager = { module = "software.amazon.awssdk:secretsmanager" }
+aws-sdk-cloudwatchlogs = { module = "software.amazon.awssdk:cloudwatchlogs" }
+aws-sdk-cloudformation = { module = "software.amazon.awssdk:cloudformation" }
 aws-cdk-lib = { module = "software.amazon.awscdk:aws-cdk-lib", version.ref = "aws_cdk_lib" }
 
 # Shared


### PR DESCRIPTION
Added in PiiTermsCollector utility with method to build a set of PII values from the TestDataCreator i.e. first names, last names, licence numbers, full DOBs, postcodes). 
Added TestRunContext utility class with a static suiteStartTime set once when the scenarios first execute (through a @BeforeAll)

Added PiiLogScanStepDefs with @AfterHook, this skips the check is the AWS_STACK_NAME is not set, It then checks over each available log group and ECS Log Group, and queries CloudWatch for each PII terms, and asserts that non are found

If any PII Data match is found within the available logs, the test will fail and the PII exposed will be displayed in the logs. 

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2053](https://govukverify.atlassian.net/browse/LIME-2053)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2053]: https://govukverify.atlassian.net/browse/LIME-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ