### PR TITLE
LIME-2124: Update workflows to use latest devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -46,41 +46,31 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@261fc3d4806db1fa66a15cc11113c456db8870a7 # v2.1.0
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Traffic test image build and push (dev)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
-          cosign-release: "v3.0.5"
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
+          role-to-assume-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_DEV }}
+          dockerfile: acceptance-tests/Dockerfile
+          docker-build-path: .
+          docker-target: traffic_test_image
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
-      - name: Create shared signing config
-        run: cosign signing-config create --with-default-services=true --no-default-rekor=true --out signing.config
-
-      - name: Build, tag, and push traffic test image to ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_TRAFFIC_DEV: ${{ secrets.ECR_REPOSITORY_TRAFFIC_DEV }}
-          IMAGE_TAG: latest
-          DOCKER_TARGET: traffic_test_image
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_DEV:$IMAGE_TAG -f acceptance-tests/Dockerfile --target $DOCKER_TARGET .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_DEV:$IMAGE_TAG
-          cosign sign --yes --signing-config signing.config --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_DEV:$IMAGE_TAG
-
-      - name: Build, tag, and push testing images to Amazon ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY_DEV: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_DEV: ${{ secrets.ECR_REPOSITORY_DEV }}
-          IMAGE_TAG: latest
-          DOCKER_TARGET: ac_test_image
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG -f acceptance-tests/Dockerfile --target $DOCKER_TARGET .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
-          cosign sign --yes --signing-config signing.config --key awskms:///${CONTAINER_SIGN_KMS_KEY_DEV} $ECR_REGISTRY/$ECR_REPOSITORY_DEV:$IMAGE_TAG
+      - name: Test image build and push (dev)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_DEV }}
+          role-to-assume-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_DEV }}
+          dockerfile: acceptance-tests/Dockerfile
+          docker-build-path: .
+          docker-target: ac_test_image
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -45,45 +45,44 @@ jobs:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@261fc3d4806db1fa66a15cc11113c456db8870a7 # v2.1.0
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - name: Traffic test image build and push (build)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
         with:
-          cosign-release: "v3.0.5"
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_TRAFFIC_BUILD }}
+          dockerfile: acceptance-tests/Dockerfile
+          docker-build-path: .
+          docker-target: traffic_test_image
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
-      - name: Create shared signing config
-        run: cosign signing-config create --with-default-services=true --no-default-rekor=true --out signing.config
+      - name: Test image build and push (build)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_BUILD }}
+          dockerfile: acceptance-tests/Dockerfile
+          docker-build-path: .
+          docker-target: ac_test_image
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
-      - name: Build, tag, and push traffic test image to ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_TRAFFIC_BUILD: ${{ secrets.ECR_REPOSITORY_TRAFFIC_BUILD }}
-          IMAGE_TAG: latest
-          DOCKER_TARGET: traffic_test_image
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_BUILD:$IMAGE_TAG -f acceptance-tests/Dockerfile --target $DOCKER_TARGET .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_BUILD:$IMAGE_TAG
-          cosign sign --yes --signing-config signing.config --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_TRAFFIC_BUILD:$IMAGE_TAG
-
-      - name: Build, tag, and push testing images to Amazon ECR
-        env:
-          CONTAINER_SIGN_KMS_KEY: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_BUILD: ${{ secrets.ECR_REPOSITORY_BUILD }}
-          ECR_REPOSITORY_STAGING: ${{ secrets.ECR_REPOSITORY_STAGING }}
-          IMAGE_TAG: latest
-          DOCKER_TARGET: ac_test_image
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG -f acceptance-tests/Dockerfile --target $DOCKER_TARGET .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
-          cosign sign --yes --signing-config signing.config --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY_BUILD:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
-          cosign sign --yes --signing-config signing.config --key awskms:///${CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$ECR_REPOSITORY_STAGING:$IMAGE_TAG
+      - name: Test image build and push (staging)
+        uses: govuk-one-login/devplatform-upload-action-ecr@d839fc3ead8c9d9f18f7a8cceb7ab4a3eab18a58 # v1.7.0
+        with:
+          artifact-bucket-name: ""
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY }}
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          ecr-repo-name: ${{ secrets.ECR_REPOSITORY_STAGING }}
+          dockerfile: acceptance-tests/Dockerfile
+          docker-build-path: .
+          docker-target: ac_test_image
+          build-and-push-image-only: "true"
+          push-latest-tag: "true"
 
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml --lint


### PR DESCRIPTION
## Proposed changes

### What changed

- Move from manual steps to build and deploy ECR repos back to the `devplatform-upload-action-ecr` action
- Remove steps `Login to Amazon ECR`, `Install Cosign` and `Create shared signing config` as they are now handled by the `devplatform-upload-action-ecr` action

### Why did it change

- Move back to the `devplatform-upload-action-ecr` action instead of using a manual workflow

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
- [LIME-2124](https://govukverify.atlassian.net/browse/LIME-2124)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->

[LIME-2124]: https://govukverify.atlassian.net/browse/LIME-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ